### PR TITLE
Add fake adapter and demo CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 yarn.lock
 .pnpm-lock.yaml
 .env
+
+dist-demo

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "demo": "tsc --project tsconfig.demo.json && node --experimental-specifier-resolution=node dist-demo/scripts/demo.js"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/scripts/demo.ts
+++ b/scripts/demo.ts
@@ -1,0 +1,69 @@
+import { createFakeProvider } from '../src/adapters/fake.js';
+import { buildWindows } from '../src/calc/prescribe.js';
+import { allocateWeeklyDeficits } from '../src/calc/weekly.js';
+import { sampleProfile } from '../src/samples/profile.js';
+
+interface CliOptions {
+  startISO: string;
+  endISO: string;
+  omitPlannedKj: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    startISO: '2024-06-10T00:00:00.000Z',
+    endISO: '2024-06-20T00:00:00.000Z',
+    omitPlannedKj: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--omit-kj') {
+      options.omitPlannedKj = true;
+    } else if (arg.startsWith('--start=')) {
+      options.startISO = normalizeISO(arg.slice('--start='.length));
+    } else if (arg.startsWith('--end=')) {
+      options.endISO = normalizeISO(arg.slice('--end='.length));
+    }
+  }
+
+  if (process.env.FAKE_OMIT_KJ === '1') {
+    options.omitPlannedKj = true;
+  }
+
+  return options;
+}
+
+function normalizeISO(value: string): string {
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    throw new Error(`Invalid ISO date provided: ${value}`);
+  }
+  return new Date(ms).toISOString();
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const provider = createFakeProvider({ omitPlannedKj: args.omitPlannedKj });
+  const workouts = await provider.getPlannedWorkouts(args.startISO, args.endISO);
+
+  if (workouts.length === 0) {
+    console.error('No workouts returned for the requested window.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const windows = buildWindows(sampleProfile, workouts);
+  const { windows: adjustedWindows, weekly } = allocateWeeklyDeficits(sampleProfile, windows, workouts);
+
+  const output = {
+    windows: adjustedWindows,
+    weekly,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/node-globals.d.ts
+++ b/scripts/node-globals.d.ts
@@ -1,0 +1,10 @@
+declare const process: {
+  env: Record<string, string | undefined>;
+  argv: string[];
+  exitCode?: number;
+};
+
+declare const console: {
+  log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};

--- a/src/adapters/fake.ts
+++ b/src/adapters/fake.ts
@@ -1,0 +1,62 @@
+import type { PlannedWorkout, Step } from '../types.js';
+import { plannedWorkouts } from '../samples/workouts.js';
+import type { PlannedWorkoutProvider } from './provider.js';
+
+export interface FakeProviderOptions {
+  /**
+   * When true, planned_kJ values will be omitted to simulate missing data from the source.
+   */
+  omitPlannedKj?: boolean;
+}
+
+function toTimestamp(iso: string): number {
+  const time = Date.parse(iso);
+  if (Number.isNaN(time)) {
+    throw new Error(`Invalid ISO timestamp: ${iso}`);
+  }
+  return time;
+}
+
+function withinRange(workout: PlannedWorkout, startISO: string, endISO: string): boolean {
+  const start = toTimestamp(startISO);
+  const end = toTimestamp(endISO);
+  const workoutStart = toTimestamp(workout.startISO);
+  const workoutEnd = toTimestamp(workout.endISO);
+  return workoutEnd >= start && workoutStart <= end;
+}
+
+function cloneSteps(steps: Step[] | undefined): Step[] | undefined {
+  return steps ? steps.map((step) => ({ ...step })) : undefined;
+}
+
+function cloneWorkout(workout: PlannedWorkout): PlannedWorkout {
+  return {
+    ...workout,
+    steps: cloneSteps(workout.steps),
+  };
+}
+
+export class FakeProvider implements PlannedWorkoutProvider {
+  private readonly omitPlannedKj: boolean;
+
+  constructor(options: FakeProviderOptions = {}) {
+    this.omitPlannedKj = Boolean(options.omitPlannedKj);
+  }
+
+  async getPlannedWorkouts(startISO: string, endISO: string): Promise<PlannedWorkout[]> {
+    const filtered = plannedWorkouts.filter((workout) => withinRange(workout, startISO, endISO));
+
+    return filtered.map((workout): PlannedWorkout => {
+      const copy = cloneWorkout(workout);
+      if (this.omitPlannedKj) {
+        copy.planned_kJ = undefined;
+        copy.kj_source = 'Estimated (steps)';
+      }
+      return copy;
+    });
+  }
+}
+
+export function createFakeProvider(options?: FakeProviderOptions): FakeProvider {
+  return new FakeProvider(options);
+}

--- a/src/adapters/provider.ts
+++ b/src/adapters/provider.ts
@@ -1,0 +1,5 @@
+import type { PlannedWorkout } from '../types.js';
+
+export interface PlannedWorkoutProvider {
+  getPlannedWorkouts(startISO: string, endISO: string): Promise<PlannedWorkout[]>;
+}

--- a/src/calc/carb.ts
+++ b/src/calc/carb.ts
@@ -1,8 +1,13 @@
-import { CarbPlan, PlannedWorkout, Profile, SessionType } from '../types';
+import type { PlannedWorkout, Profile, SessionType } from '../types.js';
 
 const HARD_SESSION_TYPES: SessionType[] = ['Threshold', 'VO2', 'Race'];
 
-export interface CarbComputationResult extends CarbPlan {
+export interface CarbComputationResult {
+  g_per_hr: number;
+  pre_g: number;
+  during_g: number;
+  post_g: number;
+  gluFruRatio: number;
   overFuelGuardApplied: boolean;
 }
 

--- a/src/calc/prescribe.ts
+++ b/src/calc/prescribe.ts
@@ -1,14 +1,15 @@
-import {
+import type {
   CarbPlan,
   MacroTargets,
   PlannedWorkout,
   Profile,
   SessionType,
   WindowPlan,
-} from '../types';
-import { CarbComputationResult, computeCarbPlan } from './carb';
+} from '../types.js';
+import { type CarbComputationResult, computeCarbPlan } from './carb.js';
 
 const MS_PER_HOUR = 1000 * 60 * 60;
+const SECONDS_PER_HOUR = 60 * 60;
 
 const HARD_SESSION_TYPES: SessionType[] = ['Threshold', 'VO2', 'Race'];
 
@@ -111,7 +112,7 @@ export function estimateWorkoutKilojoules(workout: PlannedWorkout): number {
       Rest: 0,
     };
     const watts = workout.ftp_watts_at_plan * (intensityFactor[workout.type] ?? 0.7);
-    return (watts * workout.duration_hr * MS_PER_HOUR) / 1000;
+    return (watts * workout.duration_hr * SECONDS_PER_HOUR) / 1000;
   }
 
   return workout.duration_hr * 500;

--- a/src/calc/weekly.ts
+++ b/src/calc/weekly.ts
@@ -1,5 +1,5 @@
-import { PlannedWorkout, Profile, SessionType, WeeklyPlan, WindowPlan } from '../types';
-import { computeMacroTargets, isHardSession } from './prescribe';
+import type { PlannedWorkout, Profile, SessionType, WeeklyPlan, WindowPlan } from '../types.js';
+import { computeMacroTargets, isHardSession } from './prescribe.js';
 
 function cloneWindow(window: WindowPlan): WindowPlan {
   return {

--- a/src/samples/profile.ts
+++ b/src/samples/profile.ts
@@ -1,17 +1,58 @@
-import { Profile } from '../types';
-import rawProfile from '../../data/samples/profile.json';
+import type { EfficiencyPreset, Profile, SessionType } from '../types.js';
+import rawProfile from '../../data/samples/profile.json' with { type: 'json' };
 
 type ProfileJson = typeof rawProfile;
 
 const internal: ProfileJson['internal'] = rawProfile.internal;
 
+const SEX_VALUES: Profile['sex'][] = ['M', 'F'];
+const EFFICIENCY_VALUES: EfficiencyPreset[] = ['WorldClass', 'Elite', 'Competitive', 'Enthusiast'];
+const SESSION_TYPES: SessionType[] = ['Endurance', 'Tempo', 'Threshold', 'VO2', 'Race', 'Rest'];
+
+function ensureSex(value: string): Profile['sex'] {
+  if (SEX_VALUES.includes(value as Profile['sex'])) {
+    return value as Profile['sex'];
+  }
+  throw new Error(`Invalid sex value in sample profile: ${value}`);
+}
+
+function ensureEfficiencyPreset(value: string): EfficiencyPreset {
+  if (EFFICIENCY_VALUES.includes(value as EfficiencyPreset)) {
+    return value as EfficiencyPreset;
+  }
+  throw new Error(`Invalid efficiency preset in sample profile: ${value}`);
+}
+
+function ensureSessionType(value: string): SessionType {
+  if (SESSION_TYPES.includes(value as SessionType)) {
+    return value as SessionType;
+  }
+  throw new Error(`Invalid session type in carb band: ${value}`);
+}
+
+function ensureBandTuple(values: number[]): [number, number] {
+  if (values.length !== 2) {
+    throw new Error(`Carb band must contain exactly two entries. Received: ${values}`);
+  }
+  return [values[0], values[1]];
+}
+
+const carbBands = Object.entries(internal.carbBands as Record<string, number[]>).reduce(
+  (acc, [key, values]) => {
+    const sessionType = ensureSessionType(key);
+    acc[sessionType] = ensureBandTuple(values);
+    return acc;
+  },
+  {} as Record<SessionType, [number, number]>,
+);
+
 export const sampleProfile: Profile = {
-  sex: internal.sex,
+  sex: ensureSex(internal.sex),
   age_years: internal.age_years,
   height_cm: internal.height_cm,
   weight_kg: internal.weight_kg,
   ftp_watts: internal.ftp_watts,
-  efficiencyPreset: internal.efficiencyPreset,
+  efficiencyPreset: ensureEfficiencyPreset(internal.efficiencyPreset),
   efficiency: internal.efficiency,
   activityFactorDefault: internal.activityFactorDefault,
   activityFactorOverrides: internal.activityFactorOverrides,
@@ -21,7 +62,7 @@ export const sampleProfile: Profile = {
   windowPctCap: internal.windowPctCap,
   protein_g_per_kg: internal.protein_g_per_kg,
   fat_g_per_kg_min: internal.fat_g_per_kg_min,
-  carbBands: internal.carbBands,
+  carbBands,
   carbSplit: internal.carbSplit,
   gluFruRatio: internal.gluFruRatio,
   useImperial: internal.useImperial,

--- a/src/samples/workouts.ts
+++ b/src/samples/workouts.ts
@@ -1,4 +1,4 @@
-import { PlannedWorkout } from '../types';
+import type { PlannedWorkout } from '../types.js';
 
 export const plannedWorkouts: PlannedWorkout[] = [
   {

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "outDir": "dist-demo",
+    "rootDir": ".",
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "scripts/demo.ts",
+    "scripts/node-globals.d.ts",
+    "src/adapters/**/*.ts",
+    "src/calc/**/*.ts",
+    "src/samples/**/*.ts",
+    "src/types.ts"
+  ],
+  "exclude": ["src/calc/__tests__"]
+}


### PR DESCRIPTION
## Summary
- add a provider interface plus a fake adapter that can omit planned_kJ values when desired
- add a demo CLI with its own tsconfig so local sample data can be run end-to-end
- tighten calc/profile typing so the CLI build works with NodeNext module resolution and realistic kJ fallback

## Testing
- npm run demo
- npm run demo -- --omit-kj
- npm test *(fails: vitest binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a3518a70832cb89a4bda07189439