### PR TITLE
Add skeleton UI with reactive planner state

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "demo": "tsc --project tsconfig.demo.json && node --experimental-specifier-resolution=node dist-demo/scripts/demo.js"
   },
   "dependencies": {
+    "dexie": "^4.0.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,0 +1,257 @@
+import type { ChangeEvent } from 'react';
+import { usePlannerStore } from '../state/plannerStore.js';
+import type { EfficiencyPreset, SessionType } from '../types.js';
+
+const efficiencyPresetOptions: EfficiencyPreset[] = ['WorldClass', 'Elite', 'Competitive', 'Enthusiast'];
+const sessionTypeOrder: SessionType[] = ['Endurance', 'Tempo', 'Threshold', 'VO2', 'Race', 'Rest'];
+
+function handleNumberChange(handler: (value: number) => void) {
+  return (event: ChangeEvent<HTMLInputElement>) => {
+    handler(Number(event.target.value));
+  };
+}
+
+export function SettingsPanel() {
+  const overrides = usePlannerStore((state) => state.overrides);
+  const updateOverride = usePlannerStore((state) => state.updateOverride);
+  const updateCarbBand = usePlannerStore((state) => state.updateCarbBand);
+  const updateCarbSplit = usePlannerStore((state) => state.updateCarbSplit);
+
+  return (
+    <aside className="space-y-6 rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm shadow-inner shadow-slate-950/40">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold text-emerald-200">Settings</h2>
+        <p className="text-xs text-slate-400">Adjust sliders to see the plan update instantly.</p>
+      </header>
+
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Efficiency preset</span>
+            <span className="font-medium text-slate-200">{overrides.efficiencyPreset}</span>
+          </label>
+          <select
+            className="w-full rounded-md border border-slate-700 bg-slate-950 p-2 text-sm text-slate-100"
+            value={overrides.efficiencyPreset}
+            onChange={(event) => updateOverride('efficiencyPreset', event.target.value as EfficiencyPreset)}
+          >
+            {efficiencyPresetOptions.map((preset) => (
+              <option key={preset} value={preset}>
+                {preset}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Efficiency (%)</span>
+            <span className="font-medium text-slate-200">{(overrides.efficiency * 100).toFixed(1)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={18}
+            max={28}
+            step={0.1}
+            value={overrides.efficiency * 100}
+            onChange={handleNumberChange((value) => updateOverride('efficiency', value / 100))}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Activity factor</span>
+            <span className="font-medium text-slate-200">{overrides.activityFactorDefault.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={1.2}
+            max={1.9}
+            step={0.01}
+            value={overrides.activityFactorDefault}
+            onChange={handleNumberChange((value) => updateOverride('activityFactorDefault', value))}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Weekly weight change (kg)</span>
+            <span className="font-medium text-slate-200">{overrides.targetKgPerWeek.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={-1.5}
+            max={1.5}
+            step={0.05}
+            value={overrides.targetKgPerWeek}
+            onChange={handleNumberChange((value) => updateOverride('targetKgPerWeek', value))}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Deficit cap / window</span>
+            <span className="font-medium text-slate-200">{Math.round(overrides.deficitCapPerWindow)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={1200}
+            step={10}
+            value={overrides.deficitCapPerWindow}
+            onChange={handleNumberChange((value) => updateOverride('deficitCapPerWindow', value))}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Macro defaults</h3>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Protein (g/kg)</span>
+            <span className="font-medium text-slate-200">{overrides.protein_g_per_kg.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={1.2}
+            max={2.5}
+            step={0.05}
+            value={overrides.protein_g_per_kg}
+            onChange={handleNumberChange((value) => updateOverride('protein_g_per_kg', value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Fat min (g/kg)</span>
+            <span className="font-medium text-slate-200">{overrides.fat_g_per_kg_min.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0.5}
+            max={1.5}
+            step={0.05}
+            value={overrides.fat_g_per_kg_min}
+            onChange={handleNumberChange((value) => updateOverride('fat_g_per_kg_min', value))}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Carb bands (g/hr)</h3>
+        <div className="space-y-4">
+          {sessionTypeOrder.map((session) => {
+            const band = overrides.carbBands[session];
+            if (!band) {
+              return null;
+            }
+            return (
+              <div key={session} className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                  <span>{session}</span>
+                  <span className="font-medium text-slate-200">{band[0]}–{band[1]}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="space-y-1">
+                    <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">Low</span>
+                    <input
+                      className="w-full accent-emerald-400"
+                      type="range"
+                      min={20}
+                      max={120}
+                      step={5}
+                      value={band[0]}
+                      onChange={handleNumberChange((value) => updateCarbBand(session, 0, value))}
+                    />
+                  </label>
+                  <label className="space-y-1">
+                    <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">High</span>
+                    <input
+                      className="w-full accent-emerald-400"
+                      type="range"
+                      min={band[0]}
+                      max={160}
+                      step={5}
+                      value={band[1]}
+                      onChange={handleNumberChange((value) => updateCarbBand(session, 1, value))}
+                    />
+                  </label>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Carb splits (%)</h3>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Pre</span>
+            <span className="font-medium text-slate-200">{overrides.carbSplit.pre}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={overrides.carbSplit.pre}
+            onChange={handleNumberChange((value) => updateCarbSplit('pre', value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>During</span>
+            <span className="font-medium text-slate-200">{overrides.carbSplit.during}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={overrides.carbSplit.during}
+            onChange={handleNumberChange((value) => updateCarbSplit('during', value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Post</span>
+            <span className="font-medium text-slate-200">{overrides.carbSplit.post}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={overrides.carbSplit.post}
+            onChange={handleNumberChange((value) => updateCarbSplit('post', value))}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+          <span>Glu:Fru ratio</span>
+          <span className="font-medium text-slate-200">{overrides.gluFruRatio.toFixed(2)}</span>
+        </label>
+        <input
+          className="w-full accent-emerald-400"
+          type="range"
+          min={0.5}
+          max={1.2}
+          step={0.05}
+          value={overrides.gluFruRatio}
+          onChange={handleNumberChange((value) => updateOverride('gluFruRatio', value))}
+        />
+      </section>
+    </aside>
+  );
+}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -1,0 +1,66 @@
+import { usePlannerStore } from '../state/plannerStore.js';
+
+export function OnboardingPage() {
+  const profile = usePlannerStore((state) => state.profile);
+  const workouts = usePlannerStore((state) => state.workouts);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h2 className="text-2xl font-semibold text-slate-100">Welcome to Preburner</h2>
+        <p className="text-sm text-slate-400">
+          This guided sandbox loads a sample athlete and upcoming sessions. Adjust the sliders on the left to see how the
+          nutrition engine adapts in real time.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+          <h3 className="text-sm font-semibold text-slate-200">Profile snapshot</h3>
+          <dl className="mt-3 space-y-2 text-xs text-slate-400">
+            <div className="flex justify-between">
+              <dt>Age</dt>
+              <dd>{profile.age_years}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt>Weight</dt>
+              <dd>{profile.weight_kg.toFixed(1)} kg</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt>Height</dt>
+              <dd>{profile.height_cm.toFixed(0)} cm</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt>Efficiency</dt>
+              <dd>{(profile.efficiency * 100).toFixed(1)}%</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt>Activity factor</dt>
+              <dd>{profile.activityFactorDefault.toFixed(2)}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt>Weekly goal</dt>
+              <dd>{(profile.targetKgPerWeek * profile.kcalPerKg).toFixed(0)} kcal deficit</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+          <h3 className="text-sm font-semibold text-slate-200">Sample workouts</h3>
+          <p className="mt-3 text-xs text-slate-400">
+            Loaded from the fake adapter. {workouts.length} sessions are ready for planning this week.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 sm:col-span-2 lg:col-span-1">
+          <h3 className="text-sm font-semibold text-slate-200">Next steps</h3>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-xs text-slate-400">
+            <li>Visit the Planner view to confirm session energy targets.</li>
+            <li>Open the Windows view to review fuel windows between workouts.</li>
+            <li>Check the Weekly view for deficit placement vs. target.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from 'react';
+import { usePlannerStore } from '../state/plannerStore.js';
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function PlannerPage() {
+  const workouts = usePlannerStore((state) => state.workouts);
+  const profile = usePlannerStore((state) => state.profile);
+
+  const totalPlannedKj = useMemo(
+    () =>
+      workouts.reduce((sum, workout) => {
+        return sum + (workout.planned_kJ ?? 0);
+      }, 0),
+    [workouts],
+  );
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-100">Planner</h2>
+        <p className="text-sm text-slate-400">
+          Review the upcoming sessions provided by the fake adapter. Planned energy totals drive the fueling windows and
+          macro targets below.
+        </p>
+      </header>
+
+      <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-slate-300">{workouts.length} sessions scheduled.</p>
+          <p className="text-xs uppercase tracking-wide text-slate-500">
+            Total planned energy: <span className="font-semibold text-slate-200">{totalPlannedKj.toFixed(0)} kJ</span>
+          </p>
+        </div>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {workouts.map((workout) => (
+            <article
+              key={workout.id}
+              className="space-y-3 rounded-lg border border-slate-800/80 bg-slate-950/70 p-4 shadow-sm shadow-slate-950/40"
+            >
+              <header className="space-y-1">
+                <h3 className="text-lg font-semibold text-slate-100">{workout.title ?? workout.id}</h3>
+                <p className="text-xs uppercase tracking-wide text-slate-500">
+                  {workout.type} • {workout.duration_hr.toFixed(2)} h • FTP {profile.ftp_watts ?? '—'} W
+                </p>
+                <p className="text-xs text-slate-400">{formatDate(workout.startISO)}</p>
+              </header>
+              <dl className="grid grid-cols-2 gap-2 text-xs text-slate-400">
+                <div>
+                  <dt>Planned energy</dt>
+                  <dd className="font-mono text-slate-200">{workout.planned_kJ?.toFixed(0) ?? '—'} kJ</dd>
+                </div>
+                <div>
+                  <dt>kJ source</dt>
+                  <dd>{workout.kj_source}</dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/WeeklyPage.tsx
+++ b/src/pages/WeeklyPage.tsx
@@ -1,0 +1,78 @@
+import { usePlannerStore } from '../state/plannerStore.js';
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function WeeklyPage() {
+  const weekly = usePlannerStore((state) => state.weekly);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-100">Weekly placement</h2>
+        <p className="text-sm text-slate-400">
+          Compare the target deficit against allocations from each window. When sliders adjust macro rules or deficits,
+          the bars update instantly.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {weekly.map((week) => {
+          const target = Math.abs(week.weeklyTargetDeficit_kcal);
+          const allocated = Math.abs(week.weeklyAllocated_kcal);
+          const progress = target === 0 ? 0 : Math.min(1, allocated / target);
+
+          return (
+            <article
+              key={week.weekKey}
+              className="space-y-3 rounded-lg border border-slate-800 bg-slate-950/70 p-4 shadow-sm shadow-slate-950/40"
+            >
+              <header className="space-y-1">
+                <h3 className="text-lg font-semibold text-slate-100">{week.weekKey}</h3>
+                <p className="text-xs text-slate-400">
+                  {formatDate(week.weekStartISO)} → {formatDate(week.weekEndISO)}
+                </p>
+              </header>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-500">
+                  <span>Deficit placement</span>
+                  <span className="font-semibold text-slate-200">{week.weeklyAllocated_kcal.toFixed(0)} / {target.toFixed(0)} kcal</span>
+                </div>
+                <div className="h-3 rounded-full bg-slate-800">
+                  <div
+                    className="h-full rounded-full bg-emerald-400 transition-[width] duration-300"
+                    style={{ width: `${Math.round(progress * 100)}%` }}
+                  />
+                </div>
+              </div>
+
+              {week.carryOver_kcal ? (
+                <p className="text-xs text-slate-400">Carryover: {week.carryOver_kcal.toFixed(0)} kcal</p>
+              ) : null}
+
+              <dl className="grid grid-cols-2 gap-2 text-xs text-slate-300">
+                <div>
+                  <dt className="uppercase tracking-wide text-slate-500">Protein</dt>
+                  <dd>{week.macros.protein_g.toFixed(1)} g</dd>
+                </div>
+                <div>
+                  <dt className="uppercase tracking-wide text-slate-500">Fat</dt>
+                  <dd>{week.macros.fat_g.toFixed(1)} g</dd>
+                </div>
+                <div className="col-span-2">
+                  <dt className="uppercase tracking-wide text-slate-500">Carbs</dt>
+                  <dd>{week.macros.carb_g.toFixed(1)} g</dd>
+                </div>
+              </dl>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/WindowsPage.tsx
+++ b/src/pages/WindowsPage.tsx
@@ -1,0 +1,82 @@
+import { usePlannerStore } from '../state/plannerStore.js';
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function WindowsPage() {
+  const windows = usePlannerStore((state) => state.windows);
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-100">Fuel windows</h2>
+        <p className="text-sm text-slate-400">
+          Each window tracks the energy need between workouts, the target deficit, and the recommended carbohydrate and
+          macro breakdown. Notes highlight safety rules such as hard-day protection and deficit caps.
+        </p>
+      </header>
+
+      <div className="grid gap-3">
+        {windows.map((window) => (
+          <article
+            key={`${window.prevWorkoutId}-${window.nextWorkoutId}`}
+            className="space-y-3 rounded-lg border border-slate-800 bg-slate-950/70 p-4 shadow-sm shadow-slate-950/40"
+          >
+            <header className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-100">{window.nextWorkoutType} focus</h3>
+                <p className="text-xs uppercase tracking-wide text-slate-500">Next: {window.nextWorkoutId}</p>
+              </div>
+              <p className="text-xs text-slate-400">
+                {formatDate(window.windowStartISO)} → {formatDate(window.windowEndISO)}
+              </p>
+            </header>
+
+            <dl className="grid gap-3 text-xs text-slate-300 sm:grid-cols-5">
+              <div>
+                <dt className="uppercase tracking-wide text-slate-500">Need</dt>
+                <dd className="font-mono text-slate-100">{window.need_kcal.toFixed(0)} kcal</dd>
+              </div>
+              <div>
+                <dt className="uppercase tracking-wide text-slate-500">Target</dt>
+                <dd className="font-mono text-slate-100">{window.target_kcal.toFixed(0)} kcal</dd>
+              </div>
+              <div>
+                <dt className="uppercase tracking-wide text-slate-500">Activity factor</dt>
+                <dd>{window.activityFactorApplied.toFixed(2)}</dd>
+              </div>
+              <div>
+                <dt className="uppercase tracking-wide text-slate-500">Carbs</dt>
+                <dd>
+                  {window.carbs.g_per_hr.toFixed(1)} g/hr • pre {window.carbs.pre_g.toFixed(1)} g • during{' '}
+                  {window.carbs.during_g.toFixed(1)} g
+                </dd>
+              </div>
+              <div>
+                <dt className="uppercase tracking-wide text-slate-500">Macros</dt>
+                <dd>
+                  P {window.macros.protein_g.toFixed(1)} g • F {window.macros.fat_g.toFixed(1)} g • C{' '}
+                  {window.macros.carb_g.toFixed(1)} g
+                </dd>
+              </div>
+            </dl>
+
+            {window.notes.length > 0 ? (
+              <ul className="list-disc space-y-1 pl-5 text-xs text-amber-300/80">
+                {window.notes.map((note) => (
+                  <li key={note}>{note}</li>
+                ))}
+              </ul>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/state/plannerStore.ts
+++ b/src/state/plannerStore.ts
@@ -1,0 +1,197 @@
+import { create } from 'zustand';
+import { createFakeProvider } from '../adapters/fake.js';
+import { buildWindows } from '../calc/prescribe.js';
+import { allocateWeeklyDeficits } from '../calc/weekly.js';
+import { sampleProfile } from '../samples/profile.js';
+import type {
+  PlannedWorkout,
+  Profile,
+  SessionType,
+  WindowPlan,
+  WeeklyPlan,
+} from '../types.js';
+import { loadStoredOverrides, persistOverrides } from './storage.js';
+import type { PlannerOverrides, PlannerPage, PlannerStatus } from './types.js';
+
+const DEFAULT_START_ISO = '2024-06-10T00:00:00.000Z';
+const DEFAULT_END_ISO = '2024-06-20T00:00:00.000Z';
+
+interface PlannerState {
+  status: PlannerStatus;
+  error?: string;
+  page: PlannerPage;
+  baseProfile: Profile;
+  profile: Profile;
+  overrides: PlannerOverrides;
+  workouts: PlannedWorkout[];
+  windows: WindowPlan[];
+  weekly: WeeklyPlan[];
+  init(): Promise<void>;
+  setPage(page: PlannerPage): void;
+  updateOverride<K extends keyof PlannerOverrides>(key: K, value: PlannerOverrides[K]): void;
+  updateCarbBand(type: SessionType, index: 0 | 1, value: number): void;
+  updateCarbSplit(part: 'pre' | 'during' | 'post', value: number): void;
+}
+
+function cloneCarbBands(bands: Profile['carbBands']): Profile['carbBands'] {
+  return Object.entries(bands).reduce((acc, [key, values]) => {
+    acc[key as SessionType] = [values[0], values[1]];
+    return acc;
+  }, {} as Profile['carbBands']);
+}
+
+function cloneCarbSplit(split: Profile['carbSplit']): Profile['carbSplit'] {
+  return { ...split };
+}
+
+function createDefaultOverrides(profile: Profile): PlannerOverrides {
+  return {
+    efficiencyPreset: profile.efficiencyPreset,
+    efficiency: profile.efficiency,
+    activityFactorDefault: profile.activityFactorDefault,
+    targetKgPerWeek: profile.targetKgPerWeek,
+    deficitCapPerWindow: profile.deficitCapPerWindow,
+    protein_g_per_kg: profile.protein_g_per_kg,
+    fat_g_per_kg_min: profile.fat_g_per_kg_min,
+    carbBands: cloneCarbBands(profile.carbBands),
+    carbSplit: cloneCarbSplit(profile.carbSplit),
+    gluFruRatio: profile.gluFruRatio,
+  };
+}
+
+function mergeOverrides(base: PlannerOverrides, stored?: PlannerOverrides): PlannerOverrides {
+  if (!stored) {
+    return base;
+  }
+
+  const result: PlannerOverrides = {
+    ...base,
+    ...stored,
+    carbBands: cloneCarbBands(base.carbBands),
+    carbSplit: cloneCarbSplit(base.carbSplit),
+  };
+
+  if (stored.carbBands) {
+    for (const [key, values] of Object.entries(stored.carbBands)) {
+      const session = key as SessionType;
+      if (result.carbBands[session]) {
+        result.carbBands[session] = [values[0], values[1]];
+      }
+    }
+  }
+
+  if (stored.carbSplit) {
+    result.carbSplit = cloneCarbSplit(stored.carbSplit);
+  }
+
+  return result;
+}
+
+function applyOverrides(base: Profile, overrides: PlannerOverrides): Profile {
+  return {
+    ...base,
+    efficiencyPreset: overrides.efficiencyPreset,
+    efficiency: overrides.efficiency,
+    activityFactorDefault: overrides.activityFactorDefault,
+    targetKgPerWeek: overrides.targetKgPerWeek,
+    deficitCapPerWindow: overrides.deficitCapPerWindow,
+    protein_g_per_kg: overrides.protein_g_per_kg,
+    fat_g_per_kg_min: overrides.fat_g_per_kg_min,
+    carbBands: cloneCarbBands(overrides.carbBands),
+    carbSplit: cloneCarbSplit(overrides.carbSplit),
+    gluFruRatio: overrides.gluFruRatio,
+  };
+}
+
+function recomputePlan(
+  baseProfile: Profile,
+  overrides: PlannerOverrides,
+  workouts: PlannedWorkout[],
+): { profile: Profile; windows: WindowPlan[]; weekly: WeeklyPlan[] } {
+  const profile = applyOverrides(baseProfile, overrides);
+  if (workouts.length === 0) {
+    return { profile, windows: [], weekly: [] };
+  }
+
+  const windows = buildWindows(profile, workouts);
+  const { windows: adjusted, weekly } = allocateWeeklyDeficits(profile, windows, workouts);
+  return { profile, windows: adjusted, weekly };
+}
+
+export const usePlannerStore = create<PlannerState>((set, get) => {
+  const baseProfile = { ...sampleProfile, carbBands: cloneCarbBands(sampleProfile.carbBands) };
+  const defaultOverrides = createDefaultOverrides(baseProfile);
+
+  return {
+    status: 'idle',
+    page: 'onboarding',
+    baseProfile,
+    profile: applyOverrides(baseProfile, defaultOverrides),
+    overrides: defaultOverrides,
+    workouts: [],
+    windows: [],
+    weekly: [],
+    async init() {
+      if (get().status !== 'idle') {
+        return;
+      }
+
+      set({ status: 'loading' });
+
+      try {
+        const stored = await loadStoredOverrides();
+        const overrides = mergeOverrides(defaultOverrides, stored);
+        const provider = createFakeProvider();
+        const workouts = await provider.getPlannedWorkouts(DEFAULT_START_ISO, DEFAULT_END_ISO);
+        const { profile, windows, weekly } = recomputePlan(baseProfile, overrides, workouts);
+        set({
+          status: 'ready',
+          overrides,
+          workouts,
+          profile,
+          windows,
+          weekly,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error loading plan';
+        set({ status: 'error', error: message });
+      }
+    },
+    setPage(page) {
+      set({ page });
+    },
+    updateOverride(key, value) {
+      const state = get();
+      const overrides = { ...state.overrides, [key]: value } as PlannerOverrides;
+      const { profile, windows, weekly } = recomputePlan(state.baseProfile, overrides, state.workouts);
+      set({ overrides, profile, windows, weekly });
+      void persistOverrides(overrides);
+    },
+    updateCarbBand(type, index, value) {
+      const state = get();
+      const bands = cloneCarbBands(state.overrides.carbBands);
+      const band = bands[type] ?? [0, 0];
+      if (index === 0) {
+        band[0] = value;
+        if (band[1] < value) {
+          band[1] = value;
+        }
+      } else {
+        band[1] = Math.max(value, band[0]);
+      }
+      bands[type] = band;
+      const overrides = { ...state.overrides, carbBands: bands } as PlannerOverrides;
+      const { profile, windows, weekly } = recomputePlan(state.baseProfile, overrides, state.workouts);
+      set({ overrides, profile, windows, weekly });
+      void persistOverrides(overrides);
+    },
+    updateCarbSplit(part, value) {
+      const state = get();
+      const split = { ...state.overrides.carbSplit, [part]: value } as Profile['carbSplit'];
+      const overrides = { ...state.overrides, carbSplit: split } as PlannerOverrides;
+      const { profile, windows, weekly } = recomputePlan(state.baseProfile, overrides, state.workouts);
+      set({ overrides, profile, windows, weekly });
+      void persistOverrides(overrides);
+    },
+  };
+});

--- a/src/state/storage.ts
+++ b/src/state/storage.ts
@@ -1,0 +1,47 @@
+import type { PlannerOverrides } from './types.js';
+
+interface SettingsRecord {
+  id: string;
+  overrides: PlannerOverrides;
+}
+
+let dbPromise: Promise<import('dexie').Dexie | undefined> | undefined;
+
+async function getDatabase(): Promise<import('dexie').Dexie | undefined> {
+  if (typeof indexedDB === 'undefined') {
+    return undefined;
+  }
+
+  if (!dbPromise) {
+    dbPromise = import('dexie').then(({ default: Dexie }) => {
+      const db = new Dexie('PreburnerPlanner');
+      db.version(1).stores({
+        settings: '&id',
+      });
+      return db;
+    });
+  }
+
+  return dbPromise;
+}
+
+export async function loadStoredOverrides(): Promise<PlannerOverrides | undefined> {
+  const db = await getDatabase();
+  if (!db) {
+    return undefined;
+  }
+
+  const table = db.table<SettingsRecord, string>('settings');
+  const record = await table.get('active');
+  return record?.overrides;
+}
+
+export async function persistOverrides(overrides: PlannerOverrides): Promise<void> {
+  const db = await getDatabase();
+  if (!db) {
+    return;
+  }
+
+  const table = db.table<SettingsRecord, string>('settings');
+  await table.put({ id: 'active', overrides });
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,29 @@
+import type { Profile } from '../types.js';
+
+export type PlannerPage = 'onboarding' | 'planner' | 'windows' | 'weekly';
+
+export type PlannerOverrides = Pick<
+  Profile,
+  |
+    'efficiencyPreset'
+  |
+    'efficiency'
+  |
+    'activityFactorDefault'
+  |
+    'targetKgPerWeek'
+  |
+    'deficitCapPerWindow'
+  |
+    'protein_g_per_kg'
+  |
+    'fat_g_per_kg_min'
+  |
+    'carbBands'
+  |
+    'carbSplit'
+  |
+    'gluFruRatio'
+>;
+
+export type PlannerStatus = 'idle' | 'loading' | 'ready' | 'error';


### PR DESCRIPTION
## Summary
- introduce a Zustand store that wires the fake adapter into the calc engine and persists overrides in Dexie
- add a configurable settings panel plus onboarding, planner, windows, and weekly views for the skeleton UI
- replace the app shell with navigation between pages and live recomputation when sliders move

## Testing
- `npm run test` *(fails: vitest not installed in container because npm registry access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a89c0be4832c862462ebdac71b02