### PR TITLE
Add Intervals.icu integration and connection controls

### DIFF
--- a/src/adapters/intervals.ts
+++ b/src/adapters/intervals.ts
@@ -1,0 +1,612 @@
+import type { PlannedWorkout, SessionType, Step } from '../types.js';
+import type { PlannedWorkoutProvider } from './provider.js';
+
+const ICU_BASE_URL = 'https://intervals.icu/api/v1';
+
+interface IntervalsAthleteResponse {
+  id: number;
+  ftp?: number;
+}
+
+type IntervalsTagCollection = string[] | Record<string, unknown> | undefined;
+
+interface IntervalsEventSummary {
+  id: number | string;
+  name?: string;
+  title?: string;
+  type?: string;
+  workout_type?: string;
+  sport?: string;
+  description?: string;
+  category?: string;
+  start?: string;
+  start_date?: string;
+  start_date_local?: string;
+  start_time?: string;
+  end?: string;
+  end_date?: string;
+  duration?: number;
+  planned_duration?: number;
+  planned_duration_total?: number;
+  planned_work_kj?: number;
+  planned_work?: number;
+  plannedWork?: number;
+  plannedTrainingLoad?: number;
+  planned_tss?: number;
+  planned_intensity_factor?: number;
+  ftp?: number;
+  ftp_override?: number;
+  tags?: IntervalsTagCollection;
+  labels?: string[];
+  structured_workout_id?: number;
+  structuredWorkoutId?: number;
+  workout_file_id?: number;
+  workoutFileId?: number;
+  steps?: unknown;
+}
+
+interface IntervalsEventDetail extends IntervalsEventSummary {
+  structuredWorkout?: unknown;
+  workout_file?: { id: number; ext?: string };
+  files?: { id: number; ext?: string; type?: string }[];
+}
+
+interface PlannedKilojoulesResult {
+  planned_kJ?: number;
+  source: PlannedWorkout['kj_source'];
+}
+
+function encodeBasicAuth(key: string): string {
+  if (typeof btoa === 'function') {
+    return `Basic ${btoa(`${key}:`)}`;
+  }
+  return `Basic ${Buffer.from(`${key}:`).toString('base64')}`;
+}
+
+function normaliseIso(iso?: string): string | undefined {
+  if (!iso) {
+    return undefined;
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toISOString();
+}
+
+function secondsFromEvent(event: IntervalsEventSummary): number | undefined {
+  if (typeof event.planned_duration_total === 'number' && event.planned_duration_total > 0) {
+    return event.planned_duration_total;
+  }
+  if (typeof event.planned_duration === 'number' && event.planned_duration > 0) {
+    return event.planned_duration;
+  }
+  if (typeof event.duration === 'number' && event.duration > 0) {
+    return event.duration;
+  }
+  return undefined;
+}
+
+function extractTags(collection: IntervalsTagCollection): string[] {
+  if (!collection) {
+    return [];
+  }
+  if (Array.isArray(collection)) {
+    return collection.map((tag) => String(tag));
+  }
+  return Object.keys(collection).map((key) => key);
+}
+
+function inferSessionType(
+  name: string,
+  tags: string[],
+  steps: Step[] | undefined,
+  defaultType: SessionType,
+): SessionType {
+  const lowered = name.toLowerCase();
+  const tagString = tags.map((tag) => tag.toLowerCase()).join(' ');
+
+  if (tagString.includes('rest') || lowered.includes('rest day') || lowered.includes('off bike')) {
+    return 'Rest';
+  }
+
+  if (tagString.includes('race') || lowered.includes('race') || lowered.includes('crits')) {
+    return 'Race';
+  }
+
+  if (lowered.includes('vo2') || lowered.includes('v02') || tagString.includes('vo2')) {
+    return 'VO2';
+  }
+
+  if (lowered.includes('threshold') || lowered.includes('sweet spot') || lowered.includes('sweetspot')) {
+    return 'Threshold';
+  }
+
+  if (lowered.includes('tempo') || tagString.includes('tempo')) {
+    return 'Tempo';
+  }
+
+  const maxPct = steps?.reduce((max, step) => {
+    if (step.target_type === '%FTP') {
+      const hi = step.target_hi ?? step.target_lo ?? 0;
+      return Math.max(max, hi);
+    }
+    if (step.target_type === 'Watts' && step.target_hi) {
+      return Math.max(max, step.target_hi);
+    }
+    return max;
+  }, 0);
+
+  if (maxPct && maxPct >= 115) {
+    return 'VO2';
+  }
+  if (maxPct && maxPct >= 100) {
+    return 'Threshold';
+  }
+
+  if (lowered.includes('recovery')) {
+    return 'Endurance';
+  }
+
+  return defaultType;
+}
+
+function ensureDurationHours(seconds: number | undefined, startISO?: string, endISO?: string): number {
+  if (seconds && seconds > 0) {
+    return seconds / 3600;
+  }
+  if (startISO && endISO) {
+    const start = Date.parse(startISO);
+    const end = Date.parse(endISO);
+    if (!Number.isNaN(start) && !Number.isNaN(end) && end > start) {
+      return (end - start) / 3_600_000;
+    }
+  }
+  return 0;
+}
+
+function buildEndISO(startISO: string | undefined, seconds: number | undefined, fallbackEnd?: string): string | undefined {
+  if (fallbackEnd) {
+    return normaliseIso(fallbackEnd);
+  }
+  if (!startISO || !seconds) {
+    return undefined;
+  }
+  const start = Date.parse(startISO);
+  if (Number.isNaN(start)) {
+    return undefined;
+  }
+  const endMs = start + seconds * 1000;
+  return new Date(endMs).toISOString();
+}
+
+function mapTagsToDefaultType(tags: string[], fallback: SessionType): SessionType {
+  const lowered = tags.map((tag) => tag.toLowerCase());
+  if (lowered.includes('vo2') || lowered.includes('vo₂')) {
+    return 'VO2';
+  }
+  if (lowered.includes('threshold')) {
+    return 'Threshold';
+  }
+  if (lowered.includes('tempo')) {
+    return 'Tempo';
+  }
+  if (lowered.includes('race')) {
+    return 'Race';
+  }
+  if (lowered.includes('rest')) {
+    return 'Rest';
+  }
+  return fallback;
+}
+
+function estimateFromIf(
+  ftp: number | undefined,
+  intensityFactor: number | undefined,
+  durationHr: number,
+): number | undefined {
+  if (!ftp || !intensityFactor || intensityFactor <= 0 || durationHr <= 0) {
+    return undefined;
+  }
+  const avgWatts = ftp * intensityFactor;
+  return (avgWatts * durationHr * 3600) / 1000;
+}
+
+function estimateFromTss(
+  ftp: number | undefined,
+  plannedTss: number | undefined,
+  durationHr: number,
+): number | undefined {
+  if (!ftp || !plannedTss || plannedTss <= 0 || durationHr <= 0) {
+    return undefined;
+  }
+  const ifactor = Math.sqrt(plannedTss / (durationHr * 100));
+  if (!Number.isFinite(ifactor) || ifactor <= 0) {
+    return undefined;
+  }
+  return estimateFromIf(ftp, ifactor, durationHr);
+}
+
+function sumStepKilojoules(steps: Step[], ftp: number | undefined): number | undefined {
+  if (!ftp || steps.length === 0) {
+    return undefined;
+  }
+  let total = 0;
+  for (const step of steps) {
+    if (step.target_type === '%FTP') {
+      const lo = step.target_lo ?? step.target_hi ?? 0;
+      const hi = step.target_hi ?? step.target_lo ?? 0;
+      const pct = (lo + hi) / 2 / 100;
+      total += pct * ftp * step.duration_s;
+    } else if (step.target_type === 'Watts') {
+      const lo = step.target_lo ?? step.target_hi ?? 0;
+      const hi = step.target_hi ?? step.target_lo ?? 0;
+      const watts = (lo + hi) / 2;
+      total += watts * step.duration_s;
+    }
+  }
+  if (total <= 0) {
+    return undefined;
+  }
+  return total / 1000;
+}
+
+function parseStructuredSteps(structured: unknown): Step[] | undefined {
+  if (!structured) {
+    return undefined;
+  }
+
+  if (Array.isArray(structured)) {
+    const steps: Step[] = [];
+    let cursor = 0;
+    for (const item of structured) {
+      if (!item || typeof item !== 'object') {
+        continue;
+      }
+      const duration = Number('duration' in item ? (item as any).duration : (item as any).Duration);
+      if (!Number.isFinite(duration) || duration <= 0) {
+        continue;
+      }
+      const targetType = (item as any).target_type ?? (item as any).TargetType;
+      if (typeof targetType === 'string' && targetType.toLowerCase() === 'watts') {
+        const lo = Number((item as any).target_lo ?? (item as any).TargetPower ?? (item as any).TargetLow);
+        const hi = Number((item as any).target_hi ?? (item as any).TargetPower ?? (item as any).TargetHigh ?? lo);
+        steps.push({
+          start_s: cursor,
+          duration_s: Math.round(duration),
+          target_type: 'Watts',
+          target_lo: Number.isFinite(lo) ? lo : undefined,
+          target_hi: Number.isFinite(hi) ? hi : undefined,
+        });
+      } else {
+        const lo = Number(
+          (item as any).target_lo ??
+            (item as any).TargetPower ??
+            (item as any).Power ??
+            (item as any).PowerLow ??
+            (item as any).power_low,
+        );
+        const hi = Number(
+          (item as any).target_hi ??
+            (item as any).PowerHigh ??
+            (item as any).power_high ??
+            (item as any).Power ??
+            (item as any).power,
+        );
+        const loPct = Number.isFinite(lo) ? lo * (lo <= 1 ? 100 : 1) : undefined;
+        const hiPct = Number.isFinite(hi) ? hi * (hi <= 1 ? 100 : 1) : loPct;
+        steps.push({
+          start_s: cursor,
+          duration_s: Math.round(duration),
+          target_type: '%FTP',
+          target_lo: loPct,
+          target_hi: hiPct,
+        });
+      }
+      cursor += Math.round(duration);
+    }
+    return steps.length > 0 ? steps : undefined;
+  }
+
+  if (typeof structured === 'string') {
+    return parseZwoSteps(structured);
+  }
+
+  return undefined;
+}
+
+function parseZwoSteps(zwo: string): Step[] | undefined {
+  if (!zwo.trim()) {
+    return undefined;
+  }
+
+  if (typeof DOMParser !== 'undefined') {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(zwo, 'application/xml');
+      const workout = doc.querySelector('workout') ?? doc.querySelector('Workout');
+      if (!workout) {
+        return undefined;
+      }
+      const steps: Step[] = [];
+      let cursor = 0;
+
+      const appendStep = (duration: number, lo: number, hi: number) => {
+        const durationSeconds = Math.max(1, Math.round(duration));
+        steps.push({
+          start_s: cursor,
+          duration_s: durationSeconds,
+          target_type: '%FTP',
+          target_lo: lo,
+          target_hi: hi,
+        });
+        cursor += durationSeconds;
+      };
+
+      const parsePower = (value: string | null): number => {
+        if (!value) {
+          return 0;
+        }
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+          return 0;
+        }
+        return numeric <= 1 ? numeric * 100 : numeric;
+      };
+
+      const elements = workout.children;
+      for (let i = 0; i < elements.length; i += 1) {
+        const node = elements[i];
+        const tag = node.tagName?.toLowerCase();
+        if (!tag) {
+          continue;
+        }
+        if (tag === 'steadystate') {
+          const duration = Number(node.getAttribute('Duration'));
+          const power = parsePower(node.getAttribute('Power'));
+          appendStep(duration, power, power);
+        } else if (tag === 'warmup' || tag === 'cooldown') {
+          const duration = Number(node.getAttribute('Duration'));
+          const low = parsePower(node.getAttribute('PowerLow'));
+          const high = parsePower(node.getAttribute('PowerHigh'));
+          appendStep(duration, low, high);
+        } else if (tag === 'intervalst') {
+          const repeats = Number(node.getAttribute('Repeat'));
+          const onDuration = Number(node.getAttribute('OnDuration'));
+          const offDuration = Number(node.getAttribute('OffDuration'));
+          const onPower = parsePower(node.getAttribute('OnPower'));
+          const offPower = parsePower(node.getAttribute('OffPower'));
+          const repeatCount = Number.isFinite(repeats) && repeats > 0 ? Math.round(repeats) : 1;
+          for (let r = 0; r < repeatCount; r += 1) {
+            appendStep(onDuration, onPower, onPower);
+            if (offDuration > 0) {
+              appendStep(offDuration, offPower, offPower);
+            }
+          }
+        } else if (tag === 'freeride') {
+          const duration = Number(node.getAttribute('Duration'));
+          const watts = Number(node.getAttribute('FlatRoadSpeed'));
+          if (Number.isFinite(watts) && watts > 0) {
+            const durationSeconds = Math.max(1, Math.round(duration));
+            steps.push({
+              start_s: cursor,
+              duration_s: durationSeconds,
+              target_type: 'Watts',
+              target_lo: watts,
+              target_hi: watts,
+            });
+            cursor += durationSeconds;
+          } else {
+            appendStep(duration, 55, 65);
+          }
+        }
+      }
+
+      return steps.length > 0 ? steps : undefined;
+    } catch (error) {
+      console.warn('Failed to parse ZWO structured workout', error);
+    }
+  }
+
+  return undefined;
+}
+
+function extractPlannedKilojoules(
+  event: IntervalsEventSummary,
+  steps: Step[] | undefined,
+  ftp: number | undefined,
+  durationHr: number,
+): PlannedKilojoulesResult {
+  const directCandidates = [
+    event.planned_work_kj,
+    event.planned_work,
+    event.plannedWork,
+  ];
+  for (const candidate of directCandidates) {
+    if (typeof candidate === 'number' && candidate > 0) {
+      return { planned_kJ: candidate, source: 'ICU Structured' };
+    }
+  }
+
+  if (steps && steps.length > 0) {
+    const estimated = sumStepKilojoules(steps, ftp);
+    if (typeof estimated === 'number') {
+      return { planned_kJ: estimated, source: 'Estimated (steps)' };
+    }
+  }
+
+  const fromIf = estimateFromIf(ftp, event.planned_intensity_factor, durationHr);
+  if (typeof fromIf === 'number') {
+    return { planned_kJ: fromIf, source: 'Estimated (IF/TSS)' };
+  }
+
+  const fromTss = estimateFromTss(ftp, event.planned_tss ?? (event as any).plannedTss, durationHr);
+  if (typeof fromTss === 'number') {
+    return { planned_kJ: fromTss, source: 'Estimated (IF/TSS)' };
+  }
+
+  return { planned_kJ: undefined, source: 'Estimated (IF/TSS)' };
+}
+
+async function fetchStructuredFile(
+  fetcher: (path: string, responseType?: 'json' | 'text') => Promise<unknown>,
+  athleteId: number,
+  event: IntervalsEventSummary,
+): Promise<Step[] | undefined> {
+  const detail = (await fetcher(`/athlete/${athleteId}/events/${event.id}`, 'json')) as
+    | IntervalsEventDetail
+    | undefined;
+  if (!detail) {
+    return undefined;
+  }
+
+  const structured = detail.structuredWorkout ?? detail.steps ?? (detail as any).structured_workout;
+  const parsedSteps = parseStructuredSteps(structured ?? detail.steps);
+  if (parsedSteps && parsedSteps.length > 0) {
+    return parsedSteps;
+  }
+
+  const fileId =
+    detail.structured_workout_id ??
+    detail.structuredWorkoutId ??
+    detail.workout_file_id ??
+    detail.workoutFileId ??
+    detail.workout_file?.id ??
+    detail.files?.find((file) => file.ext === 'zwo' || file.type === 'structured')?.id;
+  if (!fileId) {
+    return undefined;
+  }
+
+  const response = await fetcher(
+    `/athlete/${athleteId}/files/${fileId}?ext=zwo&resolve=true`,
+    'text',
+  );
+  if (typeof response === 'string') {
+    return parseZwoSteps(response);
+  }
+
+  return undefined;
+}
+
+export class IntervalsProvider implements PlannedWorkoutProvider {
+  private readonly apiKey: string;
+
+  private athleteId?: number;
+
+  private athleteFtp?: number;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  private async fetchFromApi(path: string, responseType: 'json' | 'text' = 'json'): Promise<any> {
+    const url = new URL(path, ICU_BASE_URL);
+    const response = await fetch(url.toString(), {
+      headers: {
+        Authorization: encodeBasicAuth(this.apiKey),
+        Accept: responseType === 'json' ? 'application/json' : 'text/plain',
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Intervals.icu request failed (${response.status}): ${body}`);
+    }
+
+    return responseType === 'json' ? response.json() : response.text();
+  }
+
+  private async ensureAthlete(): Promise<void> {
+    if (typeof this.athleteId === 'number') {
+      return;
+    }
+    const athlete = (await this.fetchFromApi('/athlete')) as IntervalsAthleteResponse;
+    if (!athlete || typeof athlete.id !== 'number') {
+      throw new Error('Unable to load Intervals.icu athlete profile');
+    }
+    this.athleteId = athlete.id;
+    if (typeof athlete.ftp === 'number') {
+      this.athleteFtp = athlete.ftp;
+    }
+  }
+
+  private buildEventsUrl(startISO: string, endISO: string): string {
+    if (typeof this.athleteId !== 'number') {
+      throw new Error('Athlete ID is not loaded');
+    }
+    const url = new URL(`/athlete/${this.athleteId}/events`, ICU_BASE_URL);
+    url.searchParams.set('start', startISO);
+    url.searchParams.set('end', endISO);
+    url.searchParams.set('category', 'WORKOUT');
+    return url.pathname + url.search;
+  }
+
+  private async loadStructuredSteps(event: IntervalsEventSummary): Promise<Step[] | undefined> {
+    if (typeof this.athleteId !== 'number') {
+      return undefined;
+    }
+    try {
+      return await fetchStructuredFile(this.fetchFromApi.bind(this), this.athleteId, event);
+    } catch (error) {
+      console.warn('Failed to load structured workout for event', event.id, error);
+      return undefined;
+    }
+  }
+
+  async getPlannedWorkouts(startISO: string, endISO: string): Promise<PlannedWorkout[]> {
+    await this.ensureAthlete();
+    if (typeof this.athleteId !== 'number') {
+      return [];
+    }
+
+    const path = this.buildEventsUrl(startISO, endISO);
+    const events = (await this.fetchFromApi(path)) as IntervalsEventSummary[];
+    if (!Array.isArray(events)) {
+      return [];
+    }
+
+    const workouts: PlannedWorkout[] = [];
+
+    for (const event of events) {
+      const start =
+        normaliseIso(event.start_date ?? event.start ?? event.start_time ?? event.start_date_local) ??
+        undefined;
+      if (!start) {
+        continue;
+      }
+      const durationSeconds = secondsFromEvent(event);
+      const end = buildEndISO(start, durationSeconds, event.end ?? event.end_date);
+      const steps = parseStructuredSteps(event.steps) ?? (await this.loadStructuredSteps(event));
+      const tags = extractTags(event.tags);
+      const defaultType = mapTagsToDefaultType(tags, 'Endurance');
+      const sessionName = event.title ?? event.name ?? 'Workout';
+      const inferredType = inferSessionType(sessionName, tags, steps, defaultType);
+      const ftp = event.ftp_override ?? event.ftp ?? this.athleteFtp;
+      const durationHr = ensureDurationHours(durationSeconds, start, end);
+      const { planned_kJ, source } = extractPlannedKilojoules(event, steps, ftp, durationHr);
+
+      workouts.push({
+        id: String(event.id),
+        source: 'intervals',
+        title: sessionName,
+        type: inferredType,
+        startISO: start,
+        endISO: end ?? start,
+        duration_hr: durationHr,
+        planned_kJ,
+        ftp_watts_at_plan: ftp,
+        steps,
+        kj_source: source,
+      });
+    }
+
+    return workouts.sort(
+      (a, b) => new Date(a.startISO).getTime() - new Date(b.startISO).getTime(),
+    );
+  }
+}
+
+export function createIntervalsProvider(apiKey: string): IntervalsProvider {
+  return new IntervalsProvider(apiKey);
+}
+

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -16,6 +16,37 @@ export function SettingsPanel() {
   const updateOverride = usePlannerStore((state) => state.updateOverride);
   const updateCarbBand = usePlannerStore((state) => state.updateCarbBand);
   const updateCarbSplit = usePlannerStore((state) => state.updateCarbSplit);
+  const connection = usePlannerStore((state) => state.connection);
+  const updateConnectionSetting = usePlannerStore((state) => state.updateConnectionSetting);
+  const refreshWorkouts = usePlannerStore((state) => state.refreshWorkouts);
+  const isRefreshing = usePlannerStore((state) => state.isRefreshing);
+  const dataSource = usePlannerStore((state) => state.dataSource);
+  const lastSyncISO = usePlannerStore((state) => state.lastSyncISO);
+  const syncError = usePlannerStore((state) => state.syncError);
+
+  const rangeSummary = (() => {
+    if (!connection.startDateISO) {
+      return 'Select a start date';
+    }
+    const start = new Date(`${connection.startDateISO}T00:00:00`);
+    if (Number.isNaN(start.getTime())) {
+      return 'Select a valid start date';
+    }
+    const end = new Date(start.getTime() + connection.rangeDays * 24 * 60 * 60 * 1000);
+    return `${start.toLocaleDateString()} → ${end.toLocaleDateString()}`;
+  })();
+
+  const lastSyncSummary = lastSyncISO
+    ? new Date(lastSyncISO).toLocaleString()
+    : dataSource === 'intervals'
+      ? 'Not synced yet'
+      : 'Using sample data';
+
+  const refreshLabel = isRefreshing
+    ? 'Refreshing…'
+    : connection.apiKey
+      ? 'Refresh from Intervals.icu'
+      : 'Load sample plan';
 
   return (
     <aside className="space-y-6 rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm shadow-inner shadow-slate-950/40">
@@ -23,6 +54,81 @@ export function SettingsPanel() {
         <h2 className="text-lg font-semibold text-emerald-200">Settings</h2>
         <p className="text-xs text-slate-400">Adjust sliders to see the plan update instantly.</p>
       </header>
+
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Intervals.icu</h3>
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-slate-400">API key</label>
+          <input
+            className="w-full rounded-md border border-slate-700 bg-slate-950 p-2 text-sm text-slate-100"
+            type="password"
+            placeholder="Paste your personal API key"
+            value={connection.apiKey}
+            onChange={(event) => updateConnectionSetting('apiKey', event.target.value)}
+          />
+          <p className="text-[0.65rem] text-slate-500">Stored locally in your browser via IndexedDB.</p>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <label className="space-y-2 text-xs uppercase tracking-wide text-slate-400">
+            <span>Start date</span>
+            <input
+              className="w-full rounded-md border border-slate-700 bg-slate-950 p-2 text-sm text-slate-100"
+              type="date"
+              value={connection.startDateISO}
+              onChange={(event) => updateConnectionSetting('startDateISO', event.target.value)}
+            />
+          </label>
+          <label className="space-y-2 text-xs uppercase tracking-wide text-slate-400">
+            <span>Days</span>
+            <div className="flex items-center gap-2">
+              <input
+                className="flex-1 accent-emerald-400"
+                type="range"
+                min={7}
+                max={14}
+                step={1}
+                value={connection.rangeDays}
+                onChange={handleNumberChange((value) => updateConnectionSetting('rangeDays', value))}
+              />
+              <span className="w-8 text-right font-semibold text-slate-200">{connection.rangeDays}</span>
+            </div>
+          </label>
+        </div>
+        <p className="text-[0.7rem] text-slate-400">Sync window: {rangeSummary}</p>
+        <div className="space-y-2">
+          <button
+            type="button"
+            className={`w-full rounded-md px-3 py-2 text-xs font-semibold uppercase tracking-wide transition-colors ${
+              isRefreshing
+                ? 'cursor-wait bg-slate-800 text-slate-400'
+                : 'bg-emerald-500 text-slate-900 hover:bg-emerald-400'
+            }`}
+            onClick={() => {
+              void refreshWorkouts();
+            }}
+            disabled={isRefreshing}
+          >
+            {refreshLabel}
+          </button>
+          <div className="rounded-md border border-slate-800/80 bg-slate-950/60 p-3 text-[0.7rem] text-slate-400">
+            <dl className="space-y-1">
+              <div className="flex justify-between">
+                <dt>Source</dt>
+                <dd className="font-medium text-slate-200">{dataSource === 'intervals' ? 'Intervals.icu' : 'Sample dataset'}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Last sync</dt>
+                <dd className="font-medium text-slate-200">{lastSyncSummary}</dd>
+              </div>
+            </dl>
+            {syncError ? (
+              <p className="mt-2 rounded-md border border-rose-900/50 bg-rose-950/40 p-2 text-rose-200">
+                {syncError}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </section>
 
       <section className="space-y-4">
         <div className="space-y-2">

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -3,14 +3,24 @@ import { usePlannerStore } from '../state/plannerStore.js';
 export function OnboardingPage() {
   const profile = usePlannerStore((state) => state.profile);
   const workouts = usePlannerStore((state) => state.workouts);
+  const dataSource = usePlannerStore((state) => state.dataSource);
+  const lastSyncISO = usePlannerStore((state) => state.lastSyncISO);
+  const syncError = usePlannerStore((state) => state.syncError);
+
+  const lastSyncLabel = lastSyncISO
+    ? new Date(lastSyncISO).toLocaleString()
+    : dataSource === 'intervals'
+      ? 'Awaiting first sync'
+      : 'Sample data in use';
 
   return (
     <section className="space-y-6">
       <header className="space-y-2">
         <h2 className="text-2xl font-semibold text-slate-100">Welcome to Preburner</h2>
         <p className="text-sm text-slate-400">
-          This guided sandbox loads a sample athlete and upcoming sessions. Adjust the sliders on the left to see how the
-          nutrition engine adapts in real time.
+          Connect your Intervals.icu account or explore the sandbox data. Enter an API key in the settings panel to sync your
+          next week of structured workouts, then adjust the sliders on the left to see how the nutrition engine adapts in real
+          time.
         </p>
       </header>
 
@@ -46,15 +56,27 @@ export function OnboardingPage() {
         </div>
 
         <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
-          <h3 className="text-sm font-semibold text-slate-200">Sample workouts</h3>
+          <h3 className="text-sm font-semibold text-slate-200">Upcoming workouts</h3>
           <p className="mt-3 text-xs text-slate-400">
-            Loaded from the fake adapter. {workouts.length} sessions are ready for planning this week.
+            {workouts.length} sessions loaded from {dataSource === 'intervals' ? 'Intervals.icu' : 'the built-in sample dataset'}.
           </p>
+          <dl className="mt-3 space-y-1 text-[0.7rem] text-slate-500">
+            <div className="flex justify-between">
+              <dt>Last sync</dt>
+              <dd className="text-slate-300">{lastSyncLabel}</dd>
+            </div>
+          </dl>
+          {syncError ? (
+            <p className="mt-2 rounded-md border border-rose-900/40 bg-rose-950/40 p-2 text-rose-200">
+              Sync issue: {syncError}
+            </p>
+          ) : null}
         </div>
 
         <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 sm:col-span-2 lg:col-span-1">
           <h3 className="text-sm font-semibold text-slate-200">Next steps</h3>
           <ul className="mt-3 list-disc space-y-2 pl-5 text-xs text-slate-400">
+            <li>Press “Refresh from Intervals.icu” once your API key is saved.</li>
             <li>Visit the Planner view to confirm session energy targets.</li>
             <li>Open the Windows view to review fuel windows between workouts.</li>
             <li>Check the Weekly view for deficit placement vs. target.</li>

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -14,6 +14,10 @@ function formatDate(iso: string) {
 export function PlannerPage() {
   const workouts = usePlannerStore((state) => state.workouts);
   const profile = usePlannerStore((state) => state.profile);
+  const dataSource = usePlannerStore((state) => state.dataSource);
+  const lastSyncISO = usePlannerStore((state) => state.lastSyncISO);
+  const syncError = usePlannerStore((state) => state.syncError);
+  const isRefreshing = usePlannerStore((state) => state.isRefreshing);
 
   const totalPlannedKj = useMemo(
     () =>
@@ -28,18 +32,30 @@ export function PlannerPage() {
       <header className="space-y-1">
         <h2 className="text-2xl font-semibold text-slate-100">Planner</h2>
         <p className="text-sm text-slate-400">
-          Review the upcoming sessions provided by the fake adapter. Planned energy totals drive the fueling windows and
-          macro targets below.
+          Review the upcoming sessions pulled from {dataSource === 'intervals' ? 'Intervals.icu' : 'the sample dataset'}. Planned
+          energy totals drive the fueling windows and macro targets below.
         </p>
+        <p className="text-xs text-slate-500">
+          {dataSource === 'intervals'
+            ? `Last sync: ${lastSyncISO ? new Date(lastSyncISO).toLocaleString() : 'Awaiting first sync'}`
+            : 'Tip: Enter your Intervals.icu API key to replace the sample plan.'}
+        </p>
+        {syncError ? (
+          <p className="text-xs text-rose-300">Sync issue: {syncError}</p>
+        ) : null}
       </header>
 
       <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-slate-300">{workouts.length} sessions scheduled.</p>
           <p className="text-xs uppercase tracking-wide text-slate-500">
-            Total planned energy: <span className="font-semibold text-slate-200">{totalPlannedKj.toFixed(0)} kJ</span>
+            Total planned energy:{' '}
+            <span className="font-semibold text-slate-200">{totalPlannedKj.toFixed(0)} kJ</span>
           </p>
         </div>
+        {isRefreshing ? (
+          <p className="mt-2 text-xs text-slate-500">Refreshing workouts…</p>
+        ) : null}
 
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           {workouts.map((workout) => (

--- a/src/state/storage.ts
+++ b/src/state/storage.ts
@@ -1,3 +1,4 @@
+import type { PlannedWorkout } from '../types.js';
 import type { PlannerOverrides } from './types.js';
 
 interface SettingsRecord {
@@ -5,9 +6,37 @@ interface SettingsRecord {
   overrides: PlannerOverrides;
 }
 
-let dbPromise: Promise<import('dexie').Dexie | undefined> | undefined;
+interface IntervalsSettingsRecord {
+  id: string;
+  apiKey: string;
+  startDateISO: string;
+  rangeDays: number;
+}
 
-async function getDatabase(): Promise<import('dexie').Dexie | undefined> {
+interface WorkoutCacheRecord {
+  id: string;
+  startISO: string;
+  endISO: string;
+  workouts: PlannedWorkout[];
+  fetchedISO: string;
+}
+
+export interface StoredIntervalsSettings {
+  apiKey: string;
+  startDateISO: string;
+  rangeDays: number;
+}
+
+export interface StoredWorkoutCache {
+  workouts: PlannedWorkout[];
+  fetchedISO: string;
+}
+
+type PlannerDatabase = import('dexie').Dexie;
+
+let dbPromise: Promise<PlannerDatabase | undefined> | undefined;
+
+async function getDatabase(): Promise<PlannerDatabase | undefined> {
   if (typeof indexedDB === 'undefined') {
     return undefined;
   }
@@ -17,6 +46,11 @@ async function getDatabase(): Promise<import('dexie').Dexie | undefined> {
       const db = new Dexie('PreburnerPlanner');
       db.version(1).stores({
         settings: '&id',
+      });
+      db.version(2).stores({
+        settings: '&id',
+        connections: '&id',
+        workoutCache: '&id',
       });
       return db;
     });
@@ -44,4 +78,88 @@ export async function persistOverrides(overrides: PlannerOverrides): Promise<voi
 
   const table = db.table<SettingsRecord, string>('settings');
   await table.put({ id: 'active', overrides });
+}
+
+export async function loadIntervalsSettings(): Promise<StoredIntervalsSettings | undefined> {
+  const db = await getDatabase();
+  if (!db) {
+    return undefined;
+  }
+
+  const table = db.table<IntervalsSettingsRecord, string>('connections');
+  const record = await table.get('intervals');
+  if (!record) {
+    return undefined;
+  }
+
+  return {
+    apiKey: record.apiKey,
+    startDateISO: record.startDateISO,
+    rangeDays: record.rangeDays,
+  };
+}
+
+export async function persistIntervalsSettings(settings: StoredIntervalsSettings): Promise<void> {
+  const db = await getDatabase();
+  if (!db) {
+    return;
+  }
+
+  const table = db.table<IntervalsSettingsRecord, string>('connections');
+  await table.put({ id: 'intervals', ...settings });
+}
+
+function buildCacheId(startISO: string, endISO: string): string {
+  return `${startISO}__${endISO}`;
+}
+
+export async function loadCachedWorkouts(
+  startISO: string,
+  endISO: string,
+): Promise<StoredWorkoutCache | undefined> {
+  const db = await getDatabase();
+  if (!db) {
+    return undefined;
+  }
+
+  const table = db.table<WorkoutCacheRecord, string>('workoutCache');
+  const record = await table.get(buildCacheId(startISO, endISO));
+  if (!record) {
+    return undefined;
+  }
+
+  return {
+    workouts: record.workouts,
+    fetchedISO: record.fetchedISO,
+  };
+}
+
+export async function persistCachedWorkouts(
+  startISO: string,
+  endISO: string,
+  workouts: PlannedWorkout[],
+  fetchedISO: string,
+): Promise<void> {
+  const db = await getDatabase();
+  if (!db) {
+    return;
+  }
+
+  const table = db.table<WorkoutCacheRecord, string>('workoutCache');
+  await table.put({
+    id: buildCacheId(startISO, endISO),
+    startISO,
+    endISO,
+    workouts,
+    fetchedISO,
+  });
+}
+
+export async function clearCachedWorkouts(): Promise<void> {
+  const db = await getDatabase();
+  if (!db) {
+    return;
+  }
+
+  await db.table<WorkoutCacheRecord, string>('workoutCache').clear();
 }


### PR DESCRIPTION
## Summary
- add an Intervals.icu provider that fetches workouts, downloads structured files, and estimates planned kJ
- persist connection settings and cached workouts in IndexedDB and expose refresh controls/state in the store
- update the settings panel and planner onboarding UI for API key entry, sync status, and data source messaging

## Testing
- `npm run test` *(fails: vitest not available in the environment because npm install is blocked by a 403 from the registry)*

## Manual verification
- Enter a valid Intervals.icu API key, pick a 7–14 day range, and press “Refresh from Intervals.icu” to confirm workouts load.
- Inspect a workout missing planned kJ and confirm the structured ZWO download populates estimated energy with the correct source badge.
- Reload the app to verify cached workouts and the saved API key/date range restore without hitting the network again.

------
https://chatgpt.com/codex/tasks/task_e_68d5b3285c54832c852d241c9dfdf0f4