### PR TITLE
Fix Intervals API base URL resolution

### DIFF
--- a/src/adapters/intervals.ts
+++ b/src/adapters/intervals.ts
@@ -1,7 +1,7 @@
 import type { PlannedWorkout, SessionType, Step } from '../types.js';
 import type { PlannedWorkoutProvider } from './provider.js';
 
-const ICU_BASE_URL = 'https://intervals.icu/api/v1';
+const ICU_BASE_URL = 'https://intervals.icu/api/v1/';
 
 interface IntervalsAthleteResponse {
   id: number;
@@ -500,7 +500,10 @@ export class IntervalsProvider implements PlannedWorkoutProvider {
   }
 
   private async fetchFromApi(path: string, responseType: 'json' | 'text' = 'json'): Promise<any> {
-    const url = new URL(path, ICU_BASE_URL);
+    const resolvedPath = path.startsWith('http')
+      ? path
+      : `${ICU_BASE_URL}${path.startsWith('/') ? path.slice(1) : path}`;
+    const url = new URL(resolvedPath);
     const response = await fetch(url.toString(), {
       headers: {
         Authorization: encodeBasicAuth(this.apiKey),


### PR DESCRIPTION
## Summary
- ensure Intervals.icu API requests always include the /api/v1 prefix by normalising the base URL before fetches

## Testing
- npm test *(fails: vitest unavailable because npm install was blocked with 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b82dfa14832ca0a49fcf184388ae