### PR TITLE
Add manual Intervals athlete ID support

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -75,6 +75,23 @@ export function SettingsPanel() {
           />
           <p className="text-[0.65rem] text-slate-500">Stored locally in your browser via IndexedDB.</p>
         </div>
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-wide text-slate-400">
+            Athlete ID <span className="text-[0.6rem] lowercase text-slate-500">(optional)</span>
+          </label>
+          <input
+            className="w-full rounded-md border border-slate-700 bg-slate-950 p-2 text-sm text-slate-100"
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            placeholder="e.g. 123456"
+            value={connection.athleteId}
+            onChange={(event) => updateConnectionSetting('athleteId', event.target.value)}
+          />
+          <p className="text-[0.65rem] text-slate-500">
+            Required if Intervals.icu returns a 405 error. Use the number from your Intervals.icu URL.
+          </p>
+        </div>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <label className="space-y-2 text-xs uppercase tracking-wide text-slate-400">
             <span>Start date</span>

--- a/src/state/storage.ts
+++ b/src/state/storage.ts
@@ -11,6 +11,7 @@ interface IntervalsSettingsRecord {
   apiKey: string;
   startDateISO: string;
   rangeDays: number;
+  athleteId?: string;
 }
 
 interface WorkoutCacheRecord {
@@ -25,6 +26,7 @@ export interface StoredIntervalsSettings {
   apiKey: string;
   startDateISO: string;
   rangeDays: number;
+  athleteId?: string;
 }
 
 export interface StoredWorkoutCache {
@@ -96,6 +98,7 @@ export async function loadIntervalsSettings(): Promise<StoredIntervalsSettings |
     apiKey: record.apiKey,
     startDateISO: record.startDateISO,
     rangeDays: record.rangeDays,
+    athleteId: record.athleteId,
   };
 }
 


### PR DESCRIPTION
## Summary
- allow passing an optional athlete ID to the Intervals provider and surface a helpful message when automatic lookup returns 405
- store an optional athlete ID in planner settings and forward it through sync operations
- add an athlete ID field to the settings panel so users can recover from Intervals.icu 405 responses

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5c02587a0832c8b4fb3308ea9b705