### PR TITLE
Default to athlete 0 for Intervals requests

### DIFF
--- a/src/adapters/__tests__/intervals-provider.test.ts
+++ b/src/adapters/__tests__/intervals-provider.test.ts
@@ -71,7 +71,7 @@ describe('IntervalsProvider', () => {
     const [profileUrl, profileInit] = fetchMock.mock.calls[0];
     expect(profileUrl.toString()).toBe('https://intervals.icu/api/v1/athlete/123');
     expect(profileInit?.headers).toMatchObject({
-      Authorization: `Basic ${Buffer.from('abc123:').toString('base64')}`,
+      Authorization: `Basic ${Buffer.from('API_KEY:abc123').toString('base64')}`,
       Accept: 'application/json',
     });
 
@@ -110,7 +110,7 @@ describe('IntervalsProvider', () => {
     await expect(
       provider.getPlannedWorkouts('2024-06-10T00:00:00.000Z', '2024-06-20T00:00:00.000Z'),
     ).rejects.toThrow(
-      'Intervals.icu rejected the automatic athlete lookup (405). Enter your athlete ID in Settings.',
+      /Intervals\.icu rejected the automatic athlete lookup \(405\)\. Set your athlete ID in settings, or pass athleteId=0 to target your own account\./,
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -147,7 +147,7 @@ describe('IntervalsProvider', () => {
     await expect(
       provider.getPlannedWorkouts('2024-06-10T00:00:00.000Z', '2024-06-20T00:00:00.000Z'),
     ).rejects.toThrow(
-      /Intervals\.icu denied access to planned workouts \(403\)\. Ensure your API key allows planned workout access on Intervals\.icu → Settings → API and that the athlete has shared planned workouts with you\./,
+      /Access denied \(403\)\. Using a personal API key\? Use Basic auth with username "API_KEY" and your key as the password\./,
     );
 
     const eventsCall = fetchMock.mock.calls.find(([url]) =>

--- a/src/adapters/intervals.ts
+++ b/src/adapters/intervals.ts
@@ -455,7 +455,7 @@ export class IntervalsProvider implements PlannedWorkoutProvider {
   private readonly apiKey: string;
   private readonly debug?: IntervalsDebugLogger;
 
-  private athleteId?: number;   // allow 0 (me) explicitly
+  private athleteId?: number; // allow 0 (me) explicitly
   private athleteFtp?: number;
 
   constructor(apiKey: string, debug?: IntervalsDebugLogger, options?: { athleteId?: number }) {
@@ -476,13 +476,17 @@ export class IntervalsProvider implements PlannedWorkoutProvider {
     const url = path.startsWith('http') ? new URL(path) : new URL(normaliseApiPath(path), ICU_BASE_URL);
     const summaryPath = `${url.pathname}${url.search}`;
 
-    this.log('info', `GET ${summaryPath}`, 'Sending request to Intervals.icu');
+    const passwordLength = this.apiKey.trim().length;
+    this.log('info', 'Auth check', `u=API_KEY passLen=${passwordLength}`);
+    this.log('info', 'GET', summaryPath);
+
+    const authorization = encodeBasicAuth(this.apiKey);
 
     let response: Response;
     try {
       response = await fetch(url.toString(), {
         headers: {
-          Authorization: encodeBasicAuth(this.apiKey),
+          Authorization: authorization,
           Accept: responseType === 'json' ? 'application/json' : 'text/plain',
         },
       });

--- a/src/state/plannerStore.ts
+++ b/src/state/plannerStore.ts
@@ -212,7 +212,7 @@ function parseAthleteId(value: string): number | undefined {
   }
 
   const rounded = Math.round(numeric);
-  return rounded > 0 ? rounded : undefined;
+  return rounded >= 0 ? rounded : undefined;
 }
 
 function computeIntervalsRange(settings: IntervalsConnectionSettings): {
@@ -323,8 +323,11 @@ export const usePlannerStore = create<PlannerState>((set, get) => {
         if (connection.apiKey) {
           pushSyncLog('info', 'Intervals.icu API key detected');
           const parsedAthleteId = parseAthleteId(connection.athleteId);
-          if (parsedAthleteId) {
+          const resolvedAthleteId = typeof parsedAthleteId === 'number' ? parsedAthleteId : 0;
+          if (typeof parsedAthleteId === 'number') {
             pushSyncLog('info', 'Using provided athlete ID', String(parsedAthleteId));
+          } else {
+            pushSyncLog('info', 'Using current athlete (ID 0)');
           }
           pushSyncLog('info', 'Sync window selected', formatRangeDetail(startISO, endISO));
           const cached = await loadCachedWorkouts(startISO, endISO);
@@ -343,7 +346,7 @@ export const usePlannerStore = create<PlannerState>((set, get) => {
               const provider = createIntervalsProvider(
                 connection.apiKey.trim(),
                 forwardIntervalsDebug,
-                { athleteId: parsedAthleteId },
+                { athleteId: resolvedAthleteId },
               );
               workouts = await provider.getPlannedWorkouts(startISO, endISO);
               dataSource = 'intervals';
@@ -469,11 +472,14 @@ export const usePlannerStore = create<PlannerState>((set, get) => {
 
         if (connection.apiKey) {
           const parsedAthleteId = parseAthleteId(connection.athleteId);
-          if (parsedAthleteId) {
+          const resolvedAthleteId = typeof parsedAthleteId === 'number' ? parsedAthleteId : 0;
+          if (typeof parsedAthleteId === 'number') {
             pushSyncLog('info', 'Using provided athlete ID', String(parsedAthleteId));
+          } else {
+            pushSyncLog('info', 'Using current athlete (ID 0)');
           }
           const provider = createIntervalsProvider(connection.apiKey.trim(), forwardIntervalsDebug, {
-            athleteId: parsedAthleteId,
+            athleteId: resolvedAthleteId,
           });
           workouts = await provider.getPlannedWorkouts(startISO, endISO);
           dataSource = 'intervals';


### PR DESCRIPTION
## Summary
- default the planner to use athlete ID 0 when no explicit ID is provided and log the selected athlete
- add debug logging of auth details and request paths while using the API_KEY Basic auth header for Intervals calls
- update Intervals provider tests to align with the new authentication behaviour and guidance messaging

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5e8b1b8cc832c96cafac967bc73e6