### PR TITLE
Add dedicated settings tab with quick adjustment panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
-import { SettingsPanel } from './components/SettingsPanel.js';
 import { WeightTracker } from './components/WeightTracker.js';
+import { QuickAdjustmentsPanel } from './components/QuickAdjustmentsPanel.js';
 import { OnboardingPage } from './pages/OnboardingPage.js';
 import { PlannerPage } from './pages/PlannerPage.js';
 import { WeeklyPage } from './pages/WeeklyPage.js';
 import { WindowsPage } from './pages/WindowsPage.js';
+import { SettingsPage } from './pages/SettingsPage.js';
 import { usePlannerStore } from './state/plannerStore.js';
 import type { PlannerPage as PlannerPageKey } from './state/types.js';
 
@@ -13,6 +14,7 @@ const pageDefinitions: { key: PlannerPageKey; label: string }[] = [
   { key: 'planner', label: 'Planner' },
   { key: 'windows', label: 'Windows' },
   { key: 'weekly', label: 'Weekly' },
+  { key: 'settings', label: 'Settings' },
 ];
 
 function usePlannerInitialization() {
@@ -31,6 +33,8 @@ function PageContent({ page }: { page: PlannerPageKey }) {
       return <WindowsPage />;
     case 'weekly':
       return <WeeklyPage />;
+    case 'settings':
+      return <SettingsPage />;
     case 'onboarding':
     default:
       return <OnboardingPage />;
@@ -96,13 +100,11 @@ export default function App() {
         </header>
 
         <div className="flex flex-col gap-6 lg:flex-row">
-          <div className="lg:w-80">
-            <SettingsPanel />
-          </div>
-          <main className="flex-1 space-y-6">
+          <aside className="flex flex-col gap-4 lg:w-80">
             <WeightTracker />
-            {content}
-          </main>
+            {page !== 'settings' ? <QuickAdjustmentsPanel /> : null}
+          </aside>
+          <main className="flex-1 space-y-6">{content}</main>
         </div>
       </div>
     </div>

--- a/src/components/OverridesControls.tsx
+++ b/src/components/OverridesControls.tsx
@@ -1,0 +1,252 @@
+import type { ChangeEvent } from 'react';
+import { usePlannerStore } from '../state/plannerStore.js';
+import type { EfficiencyPreset, SessionType } from '../types.js';
+
+const efficiencyPresetOptions: EfficiencyPreset[] = ['WorldClass', 'Elite', 'Competitive', 'Enthusiast'];
+const sessionTypeOrder: SessionType[] = ['Endurance', 'Tempo', 'Threshold', 'VO2', 'Race', 'Rest'];
+
+function handleNumberChange(handler: (value: number) => void) {
+  return (event: ChangeEvent<HTMLInputElement>) => {
+    handler(Number(event.target.value));
+  };
+}
+
+export function OverridesControls() {
+  const overrides = usePlannerStore((state) => state.overrides);
+  const updateOverride = usePlannerStore((state) => state.updateOverride);
+  const updateCarbBand = usePlannerStore((state) => state.updateCarbBand);
+  const updateCarbSplit = usePlannerStore((state) => state.updateCarbSplit);
+
+  return (
+    <div className="space-y-4">
+      <section className="space-y-2">
+        <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+          <span>Efficiency preset</span>
+          <span className="font-medium text-slate-200">{overrides.efficiencyPreset}</span>
+        </label>
+        <select
+          className="w-full rounded-md border border-slate-700 bg-slate-950 p-2 text-sm text-slate-100"
+          value={overrides.efficiencyPreset}
+          onChange={(event) => updateOverride('efficiencyPreset', event.target.value as EfficiencyPreset)}
+        >
+          {efficiencyPresetOptions.map((preset) => (
+            <option key={preset} value={preset}>
+              {preset}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Efficiency (%)</span>
+            <span className="font-medium text-slate-200">{(overrides.efficiency * 100).toFixed(1)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={18}
+            max={28}
+            step={0.1}
+            value={overrides.efficiency * 100}
+            onChange={handleNumberChange((value) => updateOverride('efficiency', value / 100))}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Activity factor</span>
+            <span className="font-medium text-slate-200">{overrides.activityFactorDefault.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={1.2}
+            max={1.9}
+            step={0.01}
+            value={overrides.activityFactorDefault}
+            onChange={handleNumberChange((value) => updateOverride('activityFactorDefault', value))}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Weekly weight change (kg)</span>
+            <span className="font-medium text-slate-200">{overrides.targetKgPerWeek.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={-1.5}
+            max={1.5}
+            step={0.05}
+            value={overrides.targetKgPerWeek}
+            onChange={handleNumberChange((value) => updateOverride('targetKgPerWeek', value))}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Deficit cap / window</span>
+            <span className="font-medium text-slate-200">{Math.round(overrides.deficitCapPerWindow)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={1200}
+            step={10}
+            value={overrides.deficitCapPerWindow}
+            onChange={handleNumberChange((value) => updateOverride('deficitCapPerWindow', value))}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Macro defaults</h3>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Protein (g/kg)</span>
+            <span className="font-medium text-slate-200">{overrides.protein_g_per_kg.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={1.2}
+            max={2.5}
+            step={0.05}
+            value={overrides.protein_g_per_kg}
+            onChange={handleNumberChange((value) => updateOverride('protein_g_per_kg', value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Fat min (g/kg)</span>
+            <span className="font-medium text-slate-200">{overrides.fat_g_per_kg_min.toFixed(2)}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0.5}
+            max={1.5}
+            step={0.05}
+            value={overrides.fat_g_per_kg_min}
+            onChange={handleNumberChange((value) => updateOverride('fat_g_per_kg_min', value))}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Carb bands (g/hr)</h3>
+        <div className="space-y-4">
+          {sessionTypeOrder.map((session) => {
+            const band = overrides.carbBands[session];
+            if (!band) {
+              return null;
+            }
+            return (
+              <div key={session} className="space-y-2">
+                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                  <span>{session}</span>
+                  <span className="font-medium text-slate-200">{band[0]}–{band[1]}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="space-y-1">
+                    <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">Low</span>
+                    <input
+                      className="w-full accent-emerald-400"
+                      type="range"
+                      min={20}
+                      max={120}
+                      step={5}
+                      value={band[0]}
+                      onChange={handleNumberChange((value) => updateCarbBand(session, 0, value))}
+                    />
+                  </label>
+                  <label className="space-y-1">
+                    <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">High</span>
+                    <input
+                      className="w-full accent-emerald-400"
+                      type="range"
+                      min={band[0]}
+                      max={160}
+                      step={5}
+                      value={band[1]}
+                      onChange={handleNumberChange((value) => updateCarbBand(session, 1, value))}
+                    />
+                  </label>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Carb splits (%)</h3>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Pre</span>
+            <span className="font-medium text-slate-200">{overrides.carbSplit.pre}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={overrides.carbSplit.pre}
+            onChange={handleNumberChange((value) => updateCarbSplit('pre', value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>During</span>
+            <span className="font-medium text-slate-200">{overrides.carbSplit.during}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={overrides.carbSplit.during}
+            onChange={handleNumberChange((value) => updateCarbSplit('during', value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+            <span>Post</span>
+            <span className="font-medium text-slate-200">{overrides.carbSplit.post}</span>
+          </label>
+          <input
+            className="w-full accent-emerald-400"
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={overrides.carbSplit.post}
+            onChange={handleNumberChange((value) => updateCarbSplit('post', value))}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+          <span>Glu:Fru ratio</span>
+          <span className="font-medium text-slate-200">{overrides.gluFruRatio.toFixed(2)}</span>
+        </label>
+        <input
+          className="w-full accent-emerald-400"
+          type="range"
+          min={0.5}
+          max={1.2}
+          step={0.05}
+          value={overrides.gluFruRatio}
+          onChange={handleNumberChange((value) => updateOverride('gluFruRatio', value))}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/components/QuickAdjustmentsPanel.tsx
+++ b/src/components/QuickAdjustmentsPanel.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { OverridesControls } from './OverridesControls.js';
+
+export function QuickAdjustmentsPanel() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <aside className="space-y-4 rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm shadow-inner shadow-slate-950/40">
+      <header className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-emerald-200">Plan adjustments</h2>
+          <p className="text-xs text-slate-400">
+            Tweak nutrition and deficit assumptions without leaving the current view.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsOpen((value) => !value)}
+          className="rounded-full border border-emerald-500/60 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-emerald-200 transition-colors hover:bg-emerald-500/10"
+        >
+          {isOpen ? 'Hide' : 'Show'}
+        </button>
+      </header>
+
+      {isOpen ? (
+        <OverridesControls />
+      ) : (
+        <p className="text-xs text-slate-500">
+          Adjustments hidden. Visit the <span className="text-emerald-300">Settings</span> tab for full controls and API sync
+          options.
+        </p>
+      )}
+    </aside>
+  );
+}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,21 +1,7 @@
-import type { ChangeEvent } from 'react';
 import { usePlannerStore } from '../state/plannerStore.js';
-import type { EfficiencyPreset, SessionType } from '../types.js';
-
-const efficiencyPresetOptions: EfficiencyPreset[] = ['WorldClass', 'Elite', 'Competitive', 'Enthusiast'];
-const sessionTypeOrder: SessionType[] = ['Endurance', 'Tempo', 'Threshold', 'VO2', 'Race', 'Rest'];
-
-function handleNumberChange(handler: (value: number) => void) {
-  return (event: ChangeEvent<HTMLInputElement>) => {
-    handler(Number(event.target.value));
-  };
-}
+import { OverridesControls } from './OverridesControls.js';
 
 export function SettingsPanel() {
-  const overrides = usePlannerStore((state) => state.overrides);
-  const updateOverride = usePlannerStore((state) => state.updateOverride);
-  const updateCarbBand = usePlannerStore((state) => state.updateCarbBand);
-  const updateCarbSplit = usePlannerStore((state) => state.updateCarbSplit);
   const connection = usePlannerStore((state) => state.connection);
   const updateConnectionSetting = usePlannerStore((state) => state.updateConnectionSetting);
   const refreshWorkouts = usePlannerStore((state) => state.refreshWorkouts);
@@ -59,7 +45,7 @@ export function SettingsPanel() {
     <aside className="space-y-6 rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-sm shadow-inner shadow-slate-950/40">
       <header className="space-y-1">
         <h2 className="text-lg font-semibold text-emerald-200">Settings</h2>
-        <p className="text-xs text-slate-400">Adjust sliders to see the plan update instantly.</p>
+        <p className="text-xs text-slate-400">Manage Intervals.icu sync and adjust nutrition assumptions.</p>
       </header>
 
       <section className="space-y-3">
@@ -112,7 +98,7 @@ export function SettingsPanel() {
                 max={14}
                 step={1}
                 value={connection.rangeDays}
-                onChange={handleNumberChange((value) => updateConnectionSetting('rangeDays', value))}
+                onChange={(event) => updateConnectionSetting('rangeDays', Number(event.target.value))}
               />
               <span className="w-8 text-right font-semibold text-slate-200">{connection.rangeDays}</span>
             </div>
@@ -179,234 +165,7 @@ export function SettingsPanel() {
         </div>
       </section>
 
-      <section className="space-y-4">
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Efficiency preset</span>
-            <span className="font-medium text-slate-200">{overrides.efficiencyPreset}</span>
-          </label>
-          <select
-            className="w-full rounded-md border border-slate-700 bg-slate-950 p-2 text-sm text-slate-100"
-            value={overrides.efficiencyPreset}
-            onChange={(event) => updateOverride('efficiencyPreset', event.target.value as EfficiencyPreset)}
-          >
-            {efficiencyPresetOptions.map((preset) => (
-              <option key={preset} value={preset}>
-                {preset}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Efficiency (%)</span>
-            <span className="font-medium text-slate-200">{(overrides.efficiency * 100).toFixed(1)}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={18}
-            max={28}
-            step={0.1}
-            value={overrides.efficiency * 100}
-            onChange={handleNumberChange((value) => updateOverride('efficiency', value / 100))}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Activity factor</span>
-            <span className="font-medium text-slate-200">{overrides.activityFactorDefault.toFixed(2)}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={1.2}
-            max={1.9}
-            step={0.01}
-            value={overrides.activityFactorDefault}
-            onChange={handleNumberChange((value) => updateOverride('activityFactorDefault', value))}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Weekly weight change (kg)</span>
-            <span className="font-medium text-slate-200">{overrides.targetKgPerWeek.toFixed(2)}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={-1.5}
-            max={1.5}
-            step={0.05}
-            value={overrides.targetKgPerWeek}
-            onChange={handleNumberChange((value) => updateOverride('targetKgPerWeek', value))}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Deficit cap / window</span>
-            <span className="font-medium text-slate-200">{Math.round(overrides.deficitCapPerWindow)}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={0}
-            max={1200}
-            step={10}
-            value={overrides.deficitCapPerWindow}
-            onChange={handleNumberChange((value) => updateOverride('deficitCapPerWindow', value))}
-          />
-        </div>
-      </section>
-
-      <section className="space-y-3">
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Macro defaults</h3>
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Protein (g/kg)</span>
-            <span className="font-medium text-slate-200">{overrides.protein_g_per_kg.toFixed(2)}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={1.2}
-            max={2.5}
-            step={0.05}
-            value={overrides.protein_g_per_kg}
-            onChange={handleNumberChange((value) => updateOverride('protein_g_per_kg', value))}
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Fat min (g/kg)</span>
-            <span className="font-medium text-slate-200">{overrides.fat_g_per_kg_min.toFixed(2)}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={0.5}
-            max={1.5}
-            step={0.05}
-            value={overrides.fat_g_per_kg_min}
-            onChange={handleNumberChange((value) => updateOverride('fat_g_per_kg_min', value))}
-          />
-        </div>
-      </section>
-
-      <section className="space-y-3">
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Carb bands (g/hr)</h3>
-        <div className="space-y-4">
-          {sessionTypeOrder.map((session) => {
-            const band = overrides.carbBands[session];
-            if (!band) {
-              return null;
-            }
-            return (
-              <div key={session} className="space-y-2">
-                <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-                  <span>{session}</span>
-                  <span className="font-medium text-slate-200">{band[0]}–{band[1]}</span>
-                </div>
-                <div className="grid grid-cols-2 gap-2">
-                  <label className="space-y-1">
-                    <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">Low</span>
-                    <input
-                      className="w-full accent-emerald-400"
-                      type="range"
-                      min={20}
-                      max={120}
-                      step={5}
-                      value={band[0]}
-                      onChange={handleNumberChange((value) => updateCarbBand(session, 0, value))}
-                    />
-                  </label>
-                  <label className="space-y-1">
-                    <span className="text-[0.65rem] uppercase tracking-wide text-slate-500">High</span>
-                    <input
-                      className="w-full accent-emerald-400"
-                      type="range"
-                      min={band[0]}
-                      max={160}
-                      step={5}
-                      value={band[1]}
-                      onChange={handleNumberChange((value) => updateCarbBand(session, 1, value))}
-                    />
-                  </label>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="space-y-3">
-        <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-300">Carb splits (%)</h3>
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Pre</span>
-            <span className="font-medium text-slate-200">{overrides.carbSplit.pre}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={0}
-            max={100}
-            step={1}
-            value={overrides.carbSplit.pre}
-            onChange={handleNumberChange((value) => updateCarbSplit('pre', value))}
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>During</span>
-            <span className="font-medium text-slate-200">{overrides.carbSplit.during}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={0}
-            max={100}
-            step={1}
-            value={overrides.carbSplit.during}
-            onChange={handleNumberChange((value) => updateCarbSplit('during', value))}
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-            <span>Post</span>
-            <span className="font-medium text-slate-200">{overrides.carbSplit.post}</span>
-          </label>
-          <input
-            className="w-full accent-emerald-400"
-            type="range"
-            min={0}
-            max={100}
-            step={1}
-            value={overrides.carbSplit.post}
-            onChange={handleNumberChange((value) => updateCarbSplit('post', value))}
-          />
-        </div>
-      </section>
-
-      <section className="space-y-2">
-        <label className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
-          <span>Glu:Fru ratio</span>
-          <span className="font-medium text-slate-200">{overrides.gluFruRatio.toFixed(2)}</span>
-        </label>
-        <input
-          className="w-full accent-emerald-400"
-          type="range"
-          min={0.5}
-          max={1.2}
-          step={0.05}
-          value={overrides.gluFruRatio}
-          onChange={handleNumberChange((value) => updateOverride('gluFruRatio', value))}
-        />
-      </section>
+      <OverridesControls />
     </aside>
   );
 }

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { estimateWorkoutKilojoules } from '../calc/prescribe.js';
 import { usePlannerStore } from '../state/plannerStore.js';
 
 function formatDate(iso: string) {
@@ -22,7 +23,7 @@ export function PlannerPage() {
   const totalPlannedKj = useMemo(
     () =>
       workouts.reduce((sum, workout) => {
-        return sum + (workout.planned_kJ ?? 0);
+        return sum + estimateWorkoutKilojoules(workout);
       }, 0),
     [workouts],
   );
@@ -58,30 +59,35 @@ export function PlannerPage() {
         ) : null}
 
         <div className="mt-4 grid gap-3 md:grid-cols-2">
-          {workouts.map((workout) => (
-            <article
-              key={workout.id}
-              className="space-y-3 rounded-lg border border-slate-800/80 bg-slate-950/70 p-4 shadow-sm shadow-slate-950/40"
-            >
-              <header className="space-y-1">
-                <h3 className="text-lg font-semibold text-slate-100">{workout.title ?? workout.id}</h3>
-                <p className="text-xs uppercase tracking-wide text-slate-500">
-                  {workout.type} • {workout.duration_hr.toFixed(2)} h • FTP {profile.ftp_watts ?? '—'} W
-                </p>
-                <p className="text-xs text-slate-400">{formatDate(workout.startISO)}</p>
-              </header>
-              <dl className="grid grid-cols-2 gap-2 text-xs text-slate-400">
-                <div>
-                  <dt>Planned energy</dt>
-                  <dd className="font-mono text-slate-200">{workout.planned_kJ?.toFixed(0) ?? '—'} kJ</dd>
-                </div>
-                <div>
-                  <dt>kJ source</dt>
-                  <dd>{workout.kj_source}</dd>
-                </div>
-              </dl>
-            </article>
-          ))}
+          {workouts.map((workout) => {
+            const plannedKj = estimateWorkoutKilojoules(workout);
+            const kjSource = workout.kj_source ?? 'Estimated (IF/TSS)';
+
+            return (
+              <article
+                key={workout.id}
+                className="space-y-3 rounded-lg border border-slate-800/80 bg-slate-950/70 p-4 shadow-sm shadow-slate-950/40"
+              >
+                <header className="space-y-1">
+                  <h3 className="text-lg font-semibold text-slate-100">{workout.title ?? workout.id}</h3>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">
+                    {workout.type} • {workout.duration_hr.toFixed(2)} h • FTP {profile.ftp_watts ?? '—'} W
+                  </p>
+                  <p className="text-xs text-slate-400">{formatDate(workout.startISO)}</p>
+                </header>
+                <dl className="grid grid-cols-2 gap-2 text-xs text-slate-400">
+                  <div>
+                    <dt>Planned energy</dt>
+                    <dd className="font-mono text-slate-200">{plannedKj.toFixed(0)} kJ</dd>
+                  </div>
+                  <div>
+                    <dt>kJ source</dt>
+                    <dd>{kjSource}</dd>
+                  </div>
+                </dl>
+              </article>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,16 @@
+import { SettingsPanel } from '../components/SettingsPanel.js';
+
+export function SettingsPage() {
+  return (
+    <section className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-100">Settings</h2>
+        <p className="text-sm text-slate-400">
+          Connect to Intervals.icu and fine tune the assumptions that drive the nutrition and deficit planning engine.
+        </p>
+      </header>
+
+      <SettingsPanel />
+    </section>
+  );
+}

--- a/src/pages/WindowsPage.tsx
+++ b/src/pages/WindowsPage.tsx
@@ -6,7 +6,7 @@ function describeNote(note: string): string {
     return 'Safety flag: >1 kg overnight drop detected — deficit halved for this window.';
   }
   if (note === WINDOW_UNDER_RECOVERY_FLAG) {
-    return 'Safety flag: Weight trending up during deficit week — deficit paused this window to prioritise recovery.';
+    return 'Safety flag: Weight loss exceeding target — deficit paused this window to prioritise recovery.';
   }
   return note;
 }

--- a/src/state/plannerStore.ts
+++ b/src/state/plannerStore.ts
@@ -352,11 +352,14 @@ function applyWeightFlags(
     }
   }
 
-  if (summary && summary.expectedDeltaKg < -0.1 && summary.actualDeltaKg > 0.25) {
-    const latest = sorted[sorted.length - 1];
-    const window = findWindowAfterDate(windows, latest.dateISO);
-    if (window && !window.notes.includes(WINDOW_UNDER_RECOVERY_FLAG)) {
-      window.notes.push(WINDOW_UNDER_RECOVERY_FLAG);
+  if (summary && summary.expectedDeltaKg < -0.1) {
+    const extraLossKg = summary.expectedDeltaKg - summary.actualDeltaKg;
+    if (extraLossKg >= 0.35) {
+      const latest = sorted[sorted.length - 1];
+      const window = findWindowAfterDate(windows, latest.dateISO);
+      if (window && !window.notes.includes(WINDOW_UNDER_RECOVERY_FLAG)) {
+        window.notes.push(WINDOW_UNDER_RECOVERY_FLAG);
+      }
     }
   }
 }

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,6 +1,6 @@
 import type { Profile } from '../types.js';
 
-export type PlannerPage = 'onboarding' | 'planner' | 'windows' | 'weekly';
+export type PlannerPage = 'onboarding' | 'planner' | 'windows' | 'weekly' | 'settings';
 
 export type PlannerOverrides = Pick<
   Profile,


### PR DESCRIPTION
## Summary
- add a dedicated Settings page to the navigation and move the inline adjustments into a collapsible quick-adjust panel beside other pages
- extract the override sliders into a shared component that powers both the quick-adjust card and the full settings tab
- improve planner statistics by estimating planned kilojoules when missing and only pause deficits when weight loss exceeds the target pace

## Testing
- npm run build *(fails: strict TypeScript config flags pre-existing implicit any and missing Node/Dexie typings)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d67709b4832caaa366b649eb35c3