### PR TITLE
Improve Intervals planned energy extraction

### DIFF
--- a/src/adapters/__tests__/fixtures/intervals_event_kid.json
+++ b/src/adapters/__tests__/fixtures/intervals_event_kid.json
@@ -1,0 +1,13 @@
+{
+  "id": 501,
+  "title": "Kid Workout",
+  "start_date": "2024-09-10T08:00:00Z",
+  "category": "WORKOUT",
+  "description": "<p>Intervals set to burn kJ(Cal) 811 for this session.</p>",
+  "icu_intensity": 81,
+  "icu_training_load": 66,
+  "moving_time": 3600,
+  "ftp": 250,
+  "workout_file_base64": "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHdvcmtvdXRfZmlsZT4KICA8d29ya291dD4KICAgIDxXYXJtdXAgRHVyYXRpb249IjYwMCIgUG93ZXJMb3c9IjAuNSIgUG93ZXJIaWdoPSIwLjc1IiAvPgogICAgPEludGVydmFsc1QgUmVwZWF0PSI0IiBPbkR1cmF0aW9uPSIyNDAiIE9mZkR1cmF0aW9uPSIxODAiIE9uUG93ZXI9IjEuMDUiIE9mZlBvd2VyPSIwLjYiIC8+CiAgICA8U3RlYWR5U3RhdGUgRHVyYXRpb249IjcyMCIgUG93ZXI9IjAuOCIgLz4KICAgIDxDb29sZG93biBEdXJhdGlvbj0iNjAwIiBQb3dlckxvdz0iMC41IiBQb3dlckhpZ2g9IjAuNjUiIC8+CiAgPC93b3Jrb3V0Pgo8L3dvcmtvdXRfZmlsZT4=",
+  "workout_filename": "Kid.zwo"
+}

--- a/src/adapters/__tests__/intervals-provider.test.ts
+++ b/src/adapters/__tests__/intervals-provider.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createIntervalsProvider } from '../intervals.js';
+import kidEvent from './fixtures/intervals_event_kid.json';
 
 function buildJsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -209,6 +210,102 @@ describe('IntervalsProvider', () => {
     expect(workout.planned_kJ).toBeCloseTo(720);
     expect(workout.steps).toHaveLength(3);
     expect(workout.endISO).not.toBe(workout.startISO);
+  });
+
+  it('parses inline ZWO workouts and description energy to populate planned kJ', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString());
+      const path = `${url.pathname}${url.search}`;
+
+      if (path === '/api/v1/athlete/0') {
+        return buildJsonResponse({ id: '0', ftp: 255 });
+      }
+
+      if (path.startsWith('/api/v1/athlete/0/wellness.json')) {
+        return buildJsonResponse([]);
+      }
+
+      if (path.startsWith('/api/v1/athlete/0/events.json')) {
+        return buildJsonResponse([kidEvent]);
+      }
+
+      throw new Error(`Unexpected fetch to ${path}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = createIntervalsProvider('abc123', undefined, { athleteId: 0 });
+
+    const workouts = await provider.getPlannedWorkouts(
+      '2024-09-09T00:00:00.000Z',
+      '2024-09-12T00:00:00.000Z',
+    );
+
+    expect(workouts).toHaveLength(1);
+    const [workout] = workouts;
+    expect(workout.duration_hr).toBeCloseTo(1);
+    expect(workout.planned_kJ).toBe(811);
+    expect(workout.kj_source).toBe('Description');
+    expect(workout.steps).toBeDefined();
+    expect(workout.steps).toHaveLength(11);
+
+    const calledDownload = fetchMock.mock.calls.some(([request]) =>
+      request.toString().includes('download.zwo'),
+    );
+    expect(calledDownload).toBe(false);
+  });
+
+  it('estimates planned kJ and session type from Intervals IF/TSS when structure is absent', async () => {
+    const event = {
+      id: 777,
+      title: 'VO2 Builder',
+      start_date: '2024-09-15T07:00:00Z',
+      category: 'WORKOUT',
+      icu_intensity: 120,
+      icu_training_load: 90,
+      moving_time: 2700,
+      ftp: 280,
+      tags: [],
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === 'string' ? input : input.toString());
+      const path = `${url.pathname}${url.search}`;
+
+      if (path === '/api/v1/athlete/0') {
+        return buildJsonResponse({ id: '0', ftp: 280 });
+      }
+
+      if (path.startsWith('/api/v1/athlete/0/wellness.json')) {
+        return buildJsonResponse([]);
+      }
+
+      if (path.startsWith('/api/v1/athlete/0/events.json')) {
+        return buildJsonResponse([event]);
+      }
+
+      if (path === '/api/v1/athlete/0/events/777?resolve=true') {
+        return buildJsonResponse({ ...event, files: [] });
+      }
+
+      throw new Error(`Unexpected fetch to ${path}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = createIntervalsProvider('abc123', undefined, { athleteId: 0 });
+
+    const workouts = await provider.getPlannedWorkouts(
+      '2024-09-14T00:00:00.000Z',
+      '2024-09-16T00:00:00.000Z',
+    );
+
+    expect(workouts).toHaveLength(1);
+    const [workout] = workouts;
+    expect(workout.planned_kJ).toBeCloseTo(907.2, 1);
+    expect(workout.kj_source).toBe('Estimated (IF/TSS)');
+    expect(workout.type).toBe('VO2');
+    expect(workout.steps).toBeUndefined();
   });
 
   it('suggests entering athlete id when automatic lookup is rejected', async () => {

--- a/src/adapters/intervals.ts
+++ b/src/adapters/intervals.ts
@@ -358,6 +358,7 @@ function inferSessionType(
   labels: string[],
   typeHints: (string | undefined)[],
   steps: Step[] | undefined,
+  intensityHints: (number | undefined)[],
   defaultType: SessionType,
 ): SessionType {
   const combined = [name, ...tags, ...labels, ...typeHints.filter((hint): hint is string => typeof hint === 'string')]
@@ -402,6 +403,17 @@ function inferSessionType(
 
   if (maxPct && maxPct >= 115) return 'VO2';
   if (maxPct && maxPct >= 100) return 'Threshold';
+
+  const intensity = intensityHints
+    .map((value) => (typeof value === 'number' && Number.isFinite(value) ? value : undefined))
+    .filter((value): value is number => typeof value === 'number')
+    .reduce((max, value) => (value > max ? value : max), 0);
+
+  if ((!steps || steps.length === 0) && intensity > 0) {
+    if (intensity >= 1.15) return 'VO2';
+    if (intensity >= 1) return 'Threshold';
+    if (intensity >= 0.85) return 'Tempo';
+  }
   if (combined.includes('recovery')) return 'Endurance';
 
   return defaultType;
@@ -537,6 +549,88 @@ function totalStepDurationSeconds(steps: Step[] | undefined): number | undefined
   return total > 0 ? total : undefined;
 }
 
+function parseKjFromDescription(desc?: string): number | undefined {
+  if (!desc) return undefined;
+  const text = desc.replace(/<[^>]+>/g, ' ');
+  const match = /\b(\d{2,5})\s*kJ\b|\bkJ(?:\(Cal\))?\s*(\d{2,5})\b/i.exec(text);
+  if (!match) return undefined;
+  const raw = match[1] ?? match[2];
+  if (!raw) return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+interface SimpleZwoNode {
+  tag: string;
+  get(name: string): string | undefined;
+}
+
+function buildStepsFromZwoNodes(nodes: SimpleZwoNode[]): Step[] | undefined {
+  if (nodes.length === 0) return undefined;
+
+  const steps: Step[] = [];
+  let cursor = 0;
+
+  const appendStep = (duration: number, lo: number, hi: number, targetType: Step['target_type']) => {
+    if (!Number.isFinite(duration) || duration <= 0) return;
+    const durationSeconds = Math.max(1, Math.round(duration));
+    steps.push({
+      start_s: cursor,
+      duration_s: durationSeconds,
+      target_type: targetType,
+      target_lo: lo,
+      target_hi: hi,
+    });
+    cursor += durationSeconds;
+  };
+
+  const parsePower = (value: string | undefined): number => {
+    if (!value) return 0;
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return 0;
+    return numeric <= 1 ? numeric * 100 : numeric;
+  };
+
+  for (const node of nodes) {
+    const tag = node.tag.toLowerCase();
+    if (!tag) continue;
+
+    if (tag === 'steadystate') {
+      const duration = Number(node.get('Duration'));
+      const power = parsePower(node.get('Power'));
+      appendStep(duration, power, power, '%FTP');
+    } else if (tag === 'warmup' || tag === 'cooldown') {
+      const duration = Number(node.get('Duration'));
+      const low = parsePower(node.get('PowerLow'));
+      const high = parsePower(node.get('PowerHigh'));
+      appendStep(duration, low, high, '%FTP');
+    } else if (tag === 'intervalst') {
+      const repeats = Number(node.get('Repeat'));
+      const onDuration = Number(node.get('OnDuration'));
+      const offDuration = Number(node.get('OffDuration'));
+      const onPower = parsePower(node.get('OnPower'));
+      const offPower = parsePower(node.get('OffPower'));
+      const repeatCount = Number.isFinite(repeats) && repeats > 0 ? Math.round(repeats) : 1;
+      for (let r = 0; r < repeatCount; r += 1) {
+        appendStep(onDuration, onPower, onPower, '%FTP');
+        if (Number.isFinite(offDuration) && offDuration > 0) {
+          appendStep(offDuration, offPower, offPower, '%FTP');
+        }
+      }
+    } else if (tag === 'freeride') {
+      const duration = Number(node.get('Duration'));
+      const watts = Number(node.get('FlatRoadSpeed'));
+      if (Number.isFinite(watts) && watts > 0) {
+        appendStep(duration, watts, watts, 'Watts');
+      } else {
+        appendStep(duration, 55, 65, '%FTP');
+      }
+    }
+  }
+
+  return steps.length > 0 ? steps : undefined;
+}
+
 function parseStructuredSteps(structured: unknown): Step[] | undefined {
   if (!structured) return undefined;
 
@@ -617,77 +711,43 @@ function parseZwoSteps(zwo: string): Step[] | undefined {
       const doc = parser.parseFromString(zwo, 'application/xml');
       const workout = doc.querySelector('workout') ?? doc.querySelector('Workout');
       if (!workout) return undefined;
-      const steps: Step[] = [];
-      let cursor = 0;
-
-      const appendStep = (duration: number, lo: number, hi: number) => {
-        const durationSeconds = Math.max(1, Math.round(duration));
-        steps.push({
-          start_s: cursor,
-          duration_s: durationSeconds,
-          target_type: '%FTP',
-          target_lo: lo,
-          target_hi: hi,
-        });
-        cursor += durationSeconds;
-      };
-
-      const parsePower = (value: string | null): number => {
-        if (!value) return 0;
-        const numeric = Number(value);
-        if (!Number.isFinite(numeric)) return 0;
-        return numeric <= 1 ? numeric * 100 : numeric;
-      };
-
+      const nodes: SimpleZwoNode[] = [];
       const elements = workout.children;
       for (let i = 0; i < elements.length; i += 1) {
-        const node = elements[i];
-        const tag = node.tagName?.toLowerCase();
-        if (!tag) continue;
-
-        if (tag === 'steadystate') {
-          const duration = Number(node.getAttribute('Duration'));
-          const power = parsePower(node.getAttribute('Power'));
-          appendStep(duration, power, power);
-        } else if (tag === 'warmup' || tag === 'cooldown') {
-          const duration = Number(node.getAttribute('Duration'));
-          const low = parsePower(node.getAttribute('PowerLow'));
-          const high = parsePower(node.getAttribute('PowerHigh'));
-          appendStep(duration, low, high);
-        } else if (tag === 'intervalst') {
-          const repeats = Number(node.getAttribute('Repeat'));
-          const onDuration = Number(node.getAttribute('OnDuration'));
-          const offDuration = Number(node.getAttribute('OffDuration'));
-          const onPower = parsePower(node.getAttribute('OnPower'));
-          const offPower = parsePower(node.getAttribute('OffPower'));
-          const repeatCount = Number.isFinite(repeats) && repeats > 0 ? Math.round(repeats) : 1;
-          for (let r = 0; r < repeatCount; r += 1) {
-            appendStep(onDuration, onPower, onPower);
-            if (offDuration > 0) appendStep(offDuration, offPower, offPower);
-          }
-        } else if (tag === 'freeride') {
-          const duration = Number(node.getAttribute('Duration'));
-          const watts = Number(node.getAttribute('FlatRoadSpeed'));
-          if (Number.isFinite(watts) && watts > 0) {
-            const durationSeconds = Math.max(1, Math.round(duration));
-            steps.push({
-              start_s: cursor,
-              duration_s: durationSeconds,
-              target_type: 'Watts',
-              target_lo: watts,
-              target_hi: watts,
-            });
-            cursor += durationSeconds;
-          } else {
-            appendStep(duration, 55, 65);
-          }
-        }
+        const element = elements[i];
+        nodes.push({
+          tag: element.tagName ?? '',
+          get: (name: string) => element.getAttribute(name) ?? element.getAttribute(name.toLowerCase()),
+        });
       }
-
-      return steps.length > 0 ? steps : undefined;
+      return buildStepsFromZwoNodes(nodes);
     } catch (error) {
       console.warn('Failed to parse ZWO structured workout', error);
     }
+  }
+
+  const elementRegex = /<(Warmup|Cooldown|SteadyState|IntervalsT|FreeRide)\b([^>]*)>/gi;
+  const nodes: SimpleZwoNode[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = elementRegex.exec(zwo)) !== null) {
+    const [, rawTag, rawAttrs] = match;
+    const attrMap: Record<string, string> = {};
+    const attrRegex = /(\w+)="([^"]*)"/g;
+    let attrMatch: RegExpExecArray | null;
+    while ((attrMatch = attrRegex.exec(rawAttrs ?? '')) !== null) {
+      const [, key, value] = attrMatch;
+      attrMap[key] = value;
+      attrMap[key.toLowerCase()] = value;
+    }
+    nodes.push({
+      tag: rawTag,
+      get: (name: string) => attrMap[name] ?? attrMap[name.toLowerCase()],
+    });
+  }
+
+  const parsed = buildStepsFromZwoNodes(nodes);
+  if (parsed && parsed.length > 0) {
+    return parsed;
   }
 
   return undefined;
@@ -707,9 +767,15 @@ function extractPlannedKilojoules(
     }
   }
 
-  const joules = toFiniteNumber(event.joules);
+  const joules = toFiniteNumber((event as any).joules ?? event.joules);
   if (typeof joules === 'number' && joules > 0) {
     return { planned_kJ: joules / 1000, source: 'ICU Structured' };
+  }
+
+  const desc = typeof event.description === 'string' ? event.description : undefined;
+  const fromDescription = parseKjFromDescription(desc);
+  if (typeof fromDescription === 'number') {
+    return { planned_kJ: fromDescription, source: 'Description' };
   }
 
   if (steps && steps.length > 0) {
@@ -717,13 +783,30 @@ function extractPlannedKilojoules(
     if (typeof estimated === 'number') return { planned_kJ: estimated, source: 'Estimated (steps)' };
   }
 
-  const fromIf = estimateFromIf(ftp, event.planned_intensity_factor, durationHr);
-  if (typeof fromIf === 'number') return { planned_kJ: fromIf, source: 'Estimated (IF/TSS)' };
+  const icuIntensityPct = toFiniteNumber((event as any).icu_intensity);
+  const icuTrainingLoad = toFiniteNumber((event as any).icu_training_load);
+  if (typeof ftp === 'number' && durationHr > 0) {
+    const intensityCandidates = [
+      typeof icuIntensityPct === 'number' && icuIntensityPct > 0 ? icuIntensityPct / 100 : undefined,
+      toFiniteNumber(event.planned_intensity_factor),
+    ];
+    for (const intensity of intensityCandidates) {
+      const fromIf = estimateFromIf(ftp, intensity, durationHr);
+      if (typeof fromIf === 'number') {
+        return { planned_kJ: fromIf, source: 'Estimated (IF/TSS)' };
+      }
+    }
 
-  const fromTss = estimateFromTss(ftp, event.planned_tss ?? (event as any).plannedTss, durationHr);
-  if (typeof fromTss === 'number') return { planned_kJ: fromTss, source: 'Estimated (IF/TSS)' };
+    const tssCandidates = [event.planned_tss, (event as any).plannedTss, icuTrainingLoad];
+    for (const tssCandidate of tssCandidates) {
+      const fromTss = estimateFromTss(ftp, toFiniteNumber(tssCandidate), durationHr);
+      if (typeof fromTss === 'number') {
+        return { planned_kJ: fromTss, source: 'Estimated (IF/TSS)' };
+      }
+    }
+  }
 
-  return { planned_kJ: undefined, source: 'Estimated (IF/TSS)' };
+  return { planned_kJ: undefined, source: 'Estimated (fallback)' };
 }
 
 async function fetchStructuredFile(
@@ -961,6 +1044,20 @@ export class IntervalsProvider implements PlannedWorkoutProvider {
   }
 
   private async loadStructuredSteps(event: IntervalsEventSummary): Promise<Step[] | undefined> {
+    const inline = (event as any).workout_file_base64;
+    const inlineExt = (event as any).workout_filename;
+    if (inline && typeof inline === 'string' && /zwo$/i.test(typeof inlineExt === 'string' ? inlineExt : '')) {
+      try {
+        const decoded = typeof Buffer !== 'undefined' ? Buffer.from(inline, 'base64').toString('utf-8') : atob(inline);
+        const parsedInline = parseZwoSteps(decoded);
+        if (parsedInline && parsedInline.length > 0) {
+          return parsedInline;
+        }
+      } catch {
+        // ignore inline parsing issues and fall back to API fetch below
+      }
+    }
+
     if (typeof this.athleteId !== 'number') return undefined;
     try {
       this.log('info', `Fetching structured workout for event ${event.id}`);
@@ -1046,12 +1143,17 @@ export class IntervalsProvider implements PlannedWorkoutProvider {
       const labels = Array.isArray(event.labels) ? event.labels.map((label) => String(label)) : [];
       const defaultType = mapTagsToDefaultType([...tags, ...labels], 'Endurance');
       const sessionName = event.title ?? event.name ?? 'Workout';
+      const icuIntensityPct = toFiniteNumber((event as any).icu_intensity);
       const inferredType = inferSessionType(
         sessionName,
         tags,
         labels,
         [event.type, event.workout_type, event.sport, event.category, event.description],
         steps,
+        [
+          toFiniteNumber(event.planned_intensity_factor),
+          typeof icuIntensityPct === 'number' ? icuIntensityPct / 100 : undefined,
+        ],
         defaultType,
       );
       const ftp = event.ftp_override ?? event.ftp ?? this.athleteFtp;

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -23,7 +23,9 @@ export function PlannerPage() {
   const totalPlannedKj = useMemo(
     () =>
       workouts.reduce((sum, workout) => {
-        return sum + estimateWorkoutKilojoules(workout);
+        const planned = typeof workout.planned_kJ === 'number' ? workout.planned_kJ : undefined;
+        const estimated = planned ?? estimateWorkoutKilojoules(workout);
+        return sum + estimated;
       }, 0),
     [workouts],
   );
@@ -51,7 +53,7 @@ export function PlannerPage() {
           <p className="text-sm text-slate-300">{workouts.length} sessions scheduled.</p>
           <p className="text-xs uppercase tracking-wide text-slate-500">
             Total planned energy:{' '}
-            <span className="font-semibold text-slate-200">{totalPlannedKj.toFixed(0)} kJ</span>
+            <span className="font-semibold text-slate-200">{Math.round(totalPlannedKj)} kJ</span>
           </p>
         </div>
         {isRefreshing ? (
@@ -60,8 +62,10 @@ export function PlannerPage() {
 
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           {workouts.map((workout) => {
-            const plannedKj = estimateWorkoutKilojoules(workout);
-            const kjSource = workout.kj_source ?? 'Estimated (IF/TSS)';
+            const plannedValue =
+              typeof workout.planned_kJ === 'number' ? workout.planned_kJ : estimateWorkoutKilojoules(workout);
+            const kjSource = workout.kj_source ?? 'Estimated (fallback)';
+            const plannedKjDisplay = Math.round(plannedValue);
             const ftpDisplay = workout.ftp_watts_at_plan ?? profile.ftp_watts;
 
             return (
@@ -80,7 +84,7 @@ export function PlannerPage() {
                 <dl className="grid grid-cols-2 gap-2 text-xs text-slate-400">
                   <div>
                     <dt>Planned energy</dt>
-                    <dd className="font-mono text-slate-200">{plannedKj.toFixed(0)} kJ</dd>
+                    <dd className="font-mono text-slate-200">{plannedKjDisplay} kJ</dd>
                   </div>
                   <div>
                     <dt>kJ source</dt>


### PR DESCRIPTION
## Summary
- expand the Intervals adapter to parse inline ZWO structure, capture description-based planned kJ, and leverage IF/TSS hints for sessions without steps
- prefer imported planned_kJ values in the planner UI while still showing fallback estimates when data is missing
- add fixtures and test coverage for inline ZWO workouts and IF/TSS-derived energy calculations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d73f0ab1d0832cba8fbb6e2d41c29b