### PR TITLE
Fetch weight history from Intervals.icu and add timeframe selector

### DIFF
--- a/src/adapters/__tests__/intervals-provider.test.ts
+++ b/src/adapters/__tests__/intervals-provider.test.ts
@@ -34,6 +34,14 @@ describe('IntervalsProvider', () => {
         });
       }
 
+      if (path.startsWith('/api/v1/athlete/0/wellness.csv')) {
+        const body = ['date,weight', '2024-06-01,70.4', '2024-06-05,70.1'].join('\n');
+        return new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': 'text/csv' },
+        });
+      }
+
       if (path.startsWith('/api/v1/athlete/0/wellness.json')) {
         return buildJsonResponse([
           { date: '2024-06-01', weight: 70.4 },


### PR DESCRIPTION
## Summary
- request a full year of weight history from Intervals.icu using the wellness API with a CSV-first fallback
- expose the synced weight trend with 1M/3M/1Y timeframe filters in the weight tracker UI
- cover the CSV wellness request in the Intervals provider test to keep expectations aligned

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d7d9cd667c832c847e7022e6015e37