### PR TITLE
Replace PWA icons with placeholders

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: npm run build
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0f172a" />
+    <link rel="manifest" href="./manifest.webmanifest" />
     <title>Preburner</title>
   </head>
   <body class="bg-slate-950 text-slate-100">

--- a/public/icons/README.md
+++ b/public/icons/README.md
@@ -1,0 +1,17 @@
+# Preburner PWA Icon Placeholders
+
+The `.png` files in this directory are plain-text placeholders so the CI/build
+pipeline can reference the expected filenames without shipping binary assets
+from the agent environment.
+
+Before releasing, replace each placeholder with the actual exported PNG icon of
+the indicated dimensions:
+
+- `icon-192.png` – 192×192 standard icon
+- `icon-512.png` – 512×512 standard icon
+- `icon-maskable-192.png` – 192×192 maskable icon with safe padding
+- `icon-maskable-512.png` – 512×512 maskable icon with safe padding
+
+All icons should follow the PWA manifest recommendations (square canvas,
+transparent background for maskable variants) and live in this directory with
+the same filenames referenced by `public/manifest.webmanifest`.

--- a/public/icons/icon-192.png
+++ b/public/icons/icon-192.png
@@ -1,0 +1,2 @@
+Placeholder icon for Preburner PWA.
+Provide a 192x192 PNG asset named icon-192.png before shipping.

--- a/public/icons/icon-512.png
+++ b/public/icons/icon-512.png
@@ -1,0 +1,2 @@
+Placeholder icon for Preburner PWA.
+Provide a 512x512 PNG asset named icon-512.png before shipping.

--- a/public/icons/icon-maskable-192.png
+++ b/public/icons/icon-maskable-192.png
@@ -1,0 +1,2 @@
+Placeholder maskable icon for Preburner PWA.
+Provide a 192x192 maskable PNG asset named icon-maskable-192.png before shipping.

--- a/public/icons/icon-maskable-512.png
+++ b/public/icons/icon-maskable-512.png
@@ -1,0 +1,2 @@
+Placeholder maskable icon for Preburner PWA.
+Provide a 512x512 maskable PNG asset named icon-maskable-512.png before shipping.

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,35 @@
+{
+  "name": "Preburner Planner",
+  "short_name": "Preburner",
+  "id": "preburner.app",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#10b981",
+  "description": "Plan fueling windows and weight goals for Intervals.icu athletes, online or offline.",
+  "icons": [
+    {
+      "src": "icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "icons/icon-maskable-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/scripts/pwaPlugin.ts
+++ b/scripts/pwaPlugin.ts
@@ -1,0 +1,91 @@
+import { fileURLToPath } from 'node:url';
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+
+const serviceWorkerSource = fileURLToPath(new URL('../src/service-worker.ts', import.meta.url));
+const serviceWorkerRequestPath = '/sw.js';
+const virtualModuleId = 'virtual:preburner-sw-register';
+const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+
+function injectDevMiddleware(server: ViteDevServer): void {
+  server.watcher.add(serviceWorkerSource);
+
+  server.middlewares.use((req, res, next) => {
+    if (!req.url || !req.url.endsWith(serviceWorkerRequestPath)) {
+      next();
+      return;
+    }
+
+    server
+      .transformRequest('/src/service-worker.ts')
+      .then((result) => {
+        if (!result) {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+
+        res.setHeader('Content-Type', 'application/javascript');
+        res.end(result.code);
+      })
+      .catch((error) => {
+        res.statusCode = 500;
+        res.end(String(error));
+      });
+  });
+}
+
+export function preburnerPwaPlugin(): Plugin {
+  let resolvedConfig: ResolvedConfig | undefined;
+
+  return {
+    name: 'preburner-pwa-plugin',
+    enforce: 'post',
+    configResolved(config) {
+      resolvedConfig = config;
+    },
+    resolveId(id) {
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+      return undefined;
+    },
+    load(id) {
+      if (id === resolvedVirtualModuleId) {
+        const base = resolvedConfig?.base ?? '/';
+        const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+        const swPath = `${normalizedBase}${serviceWorkerRequestPath}` || serviceWorkerRequestPath;
+        return `
+export function registerPreburnerServiceWorker() {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('${swPath}')
+      .catch((error) => {
+        console.error('Service worker registration failed:', error);
+      });
+  });
+}
+`;
+      }
+
+      return undefined;
+    },
+    configureServer(server) {
+      injectDevMiddleware(server);
+    },
+    buildStart() {
+      if (!resolvedConfig || resolvedConfig.command !== 'build') {
+        return;
+      }
+
+      this.emitFile({
+        type: 'chunk',
+        id: serviceWorkerSource,
+        fileName: serviceWorkerRequestPath.slice(1),
+      });
+    },
+  };
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { WeightTracker } from './components/WeightTracker.js';
 import { QuickAdjustmentsPanel } from './components/QuickAdjustmentsPanel.js';
+import { InstallPrompt } from './components/InstallPrompt.js';
+import { OfflinePlanSync } from './components/OfflinePlanSync.js';
 import { OnboardingPage } from './pages/OnboardingPage.js';
 import { PlannerPage } from './pages/PlannerPage.js';
 import { WeeklyPage } from './pages/WeeklyPage.js';
@@ -101,6 +103,8 @@ export default function App() {
               );
             })}
           </nav>
+
+          <InstallPrompt />
         </header>
 
         <div className="flex flex-col gap-6 lg:flex-row">
@@ -111,6 +115,7 @@ export default function App() {
           <main className="flex-1 space-y-6">{content}</main>
         </div>
       </div>
+      <OfflinePlanSync />
     </div>
   );
 }

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+function isStandaloneDisplay(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return window.matchMedia('(display-mode: standalone)').matches;
+}
+
+export function InstallPrompt(): JSX.Element | null {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [installed, setInstalled] = useState(isStandaloneDisplay());
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setDismissed(false);
+      setDeferredPrompt(event as BeforeInstallPromptEvent);
+    };
+
+    const handleInstalled = () => {
+      setInstalled(true);
+      setDeferredPrompt(null);
+    };
+
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+    const handleMediaChange = () => {
+      if (mediaQuery.matches) {
+        setInstalled(true);
+      }
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt as EventListener);
+    window.addEventListener('appinstalled', handleInstalled);
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleMediaChange);
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleMediaChange);
+    }
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt as EventListener);
+      window.removeEventListener('appinstalled', handleInstalled);
+      if (typeof mediaQuery.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', handleMediaChange);
+      } else if (typeof mediaQuery.removeListener === 'function') {
+        mediaQuery.removeListener(handleMediaChange);
+      }
+    };
+  }, []);
+
+  if (installed || dismissed || !deferredPrompt) {
+    return null;
+  }
+
+  const handleInstall = async () => {
+    try {
+      await deferredPrompt.prompt();
+      const outcome = await deferredPrompt.userChoice;
+      if (outcome.outcome !== 'accepted') {
+        setDeferredPrompt(null);
+      }
+    } catch (error) {
+      console.error('Unable to trigger install prompt', error);
+      setDeferredPrompt(null);
+      return;
+    }
+    setDeferredPrompt(null);
+  };
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    setDeferredPrompt(null);
+  };
+
+  return (
+    <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-100 shadow-inner shadow-emerald-500/20">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-semibold text-emerald-100">Install Preburner</p>
+          <p className="text-xs text-emerald-200/80">
+            Add the planner to your home screen so the latest synced plan stays available offline.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleInstall}
+            className="rounded-full bg-emerald-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-950 shadow hover:bg-emerald-400"
+          >
+            Install app
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="rounded-full border border-emerald-500/60 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-emerald-200 hover:bg-emerald-500/20"
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/OfflinePlanSync.tsx
+++ b/src/components/OfflinePlanSync.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { usePlannerStore } from '../state/plannerStore.js';
+
+export function OfflinePlanSync(): null {
+  const status = usePlannerStore((state) => state.status);
+  const windows = usePlannerStore((state) => state.windows);
+  const weekly = usePlannerStore((state) => state.weekly);
+  const workouts = usePlannerStore((state) => state.workouts);
+
+  useEffect(() => {
+    if (status !== 'ready') {
+      return;
+    }
+
+    if (typeof navigator === 'undefined' || !navigator.serviceWorker) {
+      return;
+    }
+
+    const payload = {
+      type: 'PREBURNER_CACHE_PLAN',
+      payload: {
+        windows,
+        weekly,
+        workouts,
+        timestamp: new Date().toISOString(),
+      },
+    } as const;
+
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        registration.active?.postMessage(payload);
+      })
+      .catch((error) => {
+        console.error('Failed to sync offline plan cache', error);
+      });
+  }, [status, windows, weekly, workouts]);
+
+  return null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,3 +15,9 @@ createRoot(container).render(
     <App />
   </StrictMode>,
 );
+
+if (import.meta.env.PROD) {
+  void import('virtual:preburner-sw-register').then(({ registerPreburnerServiceWorker }) => {
+    registerPreburnerServiceWorker();
+  });
+}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,133 @@
+/// <reference lib="WebWorker" />
+
+declare const self: ServiceWorkerGlobalScope;
+
+const APP_SHELL_CACHE = 'preburner-shell-v1';
+const DATA_CACHE = 'preburner-data-v1';
+const APP_SHELL_ASSETS = ['./', 'index.html', 'manifest.webmanifest', 'icons/icon-192.png', 'icons/icon-512.png'];
+const OFFLINE_PLAN_PATH = 'offline-plan.json';
+
+function resolveWithinScope(path: string): string {
+  const scopeUrl = new URL(self.registration.scope);
+  return new URL(path, scopeUrl).toString();
+}
+
+async function precacheAppShell(): Promise<void> {
+  const cache = await caches.open(APP_SHELL_CACHE);
+  const urls = APP_SHELL_ASSETS.map((asset) => resolveWithinScope(asset));
+  await cache.addAll(urls);
+}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(precacheAppShell());
+  self.skipWaiting();
+});
+
+async function cleanupOldCaches(): Promise<void> {
+  const keys = await caches.keys();
+  await Promise.all(
+    keys
+      .filter((key) => key.startsWith('preburner-') && key !== APP_SHELL_CACHE && key !== DATA_CACHE)
+      .map((key) => caches.delete(key)),
+  );
+}
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      await cleanupOldCaches();
+      await self.clients.claim();
+    })(),
+  );
+});
+
+async function cacheFirst(request: Request, cacheName: string): Promise<Response> {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request, { ignoreSearch: true });
+  if (cached) {
+    return cached;
+  }
+  const response = await fetch(request);
+  cache.put(request, response.clone());
+  return response;
+}
+
+async function networkFirst(request: Request, fallbackRequest: Request): Promise<Response> {
+  try {
+    const networkResponse = await fetch(request);
+    const cache = await caches.open(APP_SHELL_CACHE);
+    cache.put(fallbackRequest, networkResponse.clone());
+    return networkResponse;
+  } catch (error) {
+    const cache = await caches.open(APP_SHELL_CACHE);
+    const cached = await cache.match(fallbackRequest, { ignoreSearch: true });
+    if (cached) {
+      return cached;
+    }
+    throw error;
+  }
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  if (request.mode === 'navigate') {
+    const indexRequest = new Request(resolveWithinScope('index.html'));
+    event.respondWith(networkFirst(request, indexRequest));
+    return;
+  }
+
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (url.pathname.endsWith(OFFLINE_PLAN_PATH)) {
+    event.respondWith(cacheFirst(request, DATA_CACHE));
+    return;
+  }
+
+  if (request.destination === 'style' || request.destination === 'script' || request.destination === 'font') {
+    event.respondWith(cacheFirst(request, APP_SHELL_CACHE));
+    return;
+  }
+
+  if (request.destination === 'image' || url.pathname.endsWith('.json')) {
+    event.respondWith(cacheFirst(request, DATA_CACHE));
+  }
+});
+
+interface PlanSnapshot {
+  windows: unknown;
+  weekly: unknown;
+  workouts: unknown;
+  timestamp: string;
+}
+
+self.addEventListener('message', (event) => {
+  const data = event.data as { type?: string; payload?: PlanSnapshot } | undefined;
+  if (!data || data.type !== 'PREBURNER_CACHE_PLAN' || !data.payload) {
+    return;
+  }
+
+  const snapshot = data.payload;
+  const response = new Response(JSON.stringify(snapshot), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+
+  event.waitUntil(
+    caches.open(DATA_CACHE).then((cache) => {
+      const request = new Request(resolveWithinScope(OFFLINE_PLAN_PATH));
+      return cache.put(request, response);
+    }),
+  );
+});
+
+export {};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+declare module 'virtual:preburner-sw-register' {
+  export function registerPreburnerServiceWorker(): void;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { preburnerPwaPlugin } from './scripts/pwaPlugin.ts';
 
 export default defineConfig({
-  plugins: [react()],
+  base: './',
+  plugins: [react(), preburnerPwaPlugin()],
 });


### PR DESCRIPTION
## Summary
- replace the binary PWA icon assets with plain-text placeholders that describe the required dimensions
- add documentation under public/icons explaining how to swap in the real icons before release

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e1e13cc0832c9a66cc9156dd6207