### PR TITLE
Ensure DOM parser ZWO node getter returns undefined

### DIFF
--- a/src/adapters/intervals.ts
+++ b/src/adapters/intervals.ts
@@ -719,7 +719,10 @@ function parseZwoSteps(zwo: string): Step[] | undefined {
         const element = elements[i];
         nodes.push({
           tag: element.tagName ?? '',
-          get: (name: string) => element.getAttribute(name) ?? element.getAttribute(name.toLowerCase()),
+          get: (name: string) =>
+            element.getAttribute(name) ??
+            element.getAttribute(name.toLowerCase()) ??
+            undefined,
         });
       }
       return buildStepsFromZwoNodes(nodes);


### PR DESCRIPTION
## Summary
- ensure DOM parser branch of the ZWO parser returns `undefined` when attributes are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7efa6b834832c95f4efd9ad4eb668