### PR TITLE
Fix fetch mock destructuring in intervals provider tests

### DIFF
--- a/src/adapters/__tests__/intervals-provider.test.ts
+++ b/src/adapters/__tests__/intervals-provider.test.ts
@@ -94,7 +94,7 @@ describe('IntervalsProvider', () => {
       request.toString().includes('/athlete/0/events.json'),
     );
     expect(eventsCall).toBeDefined();
-    const [eventsUrl, eventsInit] = eventsCall!;
+    const [eventsUrl, eventsInit] = eventsCall! as Parameters<typeof fetch>;
     expect(eventsUrl.toString()).toBe(
       'https://intervals.icu/api/v1/athlete/0/events.json?oldest=2024-06-10&newest=2024-06-20&category=WORKOUT&resolve=true',
     );


### PR DESCRIPTION
## Summary
- cast the mocked fetch call tuple to match the fetch signature so the test passes TypeScript checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f07cce30832cb0bf9600a63e3bc5